### PR TITLE
fix(ui): shorten footer description on mobile

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -20,8 +20,11 @@ const startYear = 2023;
     {/* Column 1: Site identity */}
     <div class="space-y-2">
       <p class="text-foreground font-medium">funailog.com</p>
-      <p class="leading-relaxed">
+      <p class="hidden leading-relaxed sm:block">
         {t('footer.description')}
+      </p>
+      <p class="leading-relaxed sm:hidden">
+        {t('footer.descriptionShort')}
       </p>
     </div>
 

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -49,6 +49,7 @@ export const ui = {
     // Footer
     'footer.description':
       'ガジェット・仕事道具・乗り物、そして技術について綴る個人メディア。',
+    'footer.descriptionShort': 'ガジェット・道具・乗り物・技術の個人メディア。',
     // Post list / Search
     'postList.searchPlaceholder': '記事を検索…',
     'postList.searchAriaLabel': '記事を検索',
@@ -116,6 +117,7 @@ export const ui = {
     // Footer
     'footer.description':
       'A personal media about gadgets, work tools, vehicles, and technology.',
+    'footer.descriptionShort': 'Gadgets, tools, vehicles, and tech.',
     // Post list / Search
     'postList.searchPlaceholder': 'Search posts…',
     'postList.searchAriaLabel': 'Search posts',


### PR DESCRIPTION
## Summary

On narrow viewports the single long footer description paragraph wraps to 4-5 lines of `text-xs`, making column 1 tower over the nav and elsewhere columns once the layout switches to `sm:grid-cols-3`. This PR adds a shorter variant shown only on `<sm` breakpoints.

## Before / After

| Viewport | Before | After |
|:---|:---|:---|
| Desktop (≥sm) | ガジェット・仕事道具・乗り物、そして技術について綴る個人メディア。 | unchanged |
| Mobile (<sm) | same long text, 4-5 lines | **ガジェット・道具・乗り物・技術の個人メディア。** (21 chars, 1-2 lines) |

English gets an equivalent pair: the existing long description and `Gadgets, tools, vehicles, and tech.` for mobile.

## Implementation

- `src/i18n/ui.ts`: added `footer.descriptionShort` next to the existing `footer.description` for both `ja` and `en`. Long versions are untouched.
- `src/components/Footer.astro`: replaced the single `<p>` with two paragraphs, visibility toggled by Tailwind `hidden sm:block` / `sm:hidden`.

## Design note

`乗り物` (vehicles) is kept in the short form because it's a category identifier for this blog, not filler. Same reason `index.heroLine1` on the home page keeps the full enumeration — that's a separate concern and not touched here.

## Test plan

- [x] `pnpm exec astro check` → 0 errors / 0 warnings / 0 hints
- [x] `pnpm test` → 39/39 passing
- [x] `pnpm exec eslint src/components/Footer.astro` → clean
- [x] `pnpm exec prettier --check` on both files → clean
- [ ] Manual: open on mobile viewport (<640px) and confirm the short variant is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)