### PR TITLE
chore(lint): parallelize pnpm lint and drop duplicate tsc check

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "check": "astro check",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "lint": "pnpm run format && eslint --cache . && markdownlint-cli2 && pnpm run validate:content && astro check && tsc --noEmit",
+    "lint": "bash -c 'set -e; pids=(); pnpm run format:check & pids+=($!); eslint --cache . & pids+=($!); markdownlint-cli2 & pids+=($!); pnpm run validate:content & pids+=($!); astro check & pids+=($!); fail=0; for pid in \"${pids[@]}\"; do wait \"$pid\" || fail=1; done; exit $fail'",
     "lint:fix": "eslint --cache --fix . && markdownlint-cli2 --fix",
     "lint:md": "markdownlint-cli2",
     "lint:md:fix": "markdownlint-cli2 --fix",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/funailog.tsbuildinfo"
   },
   "include": [".astro/types.d.ts", "src/**/*", "astro.config.ts"],
   "exclude": ["./node_modules", "./dist"]


### PR DESCRIPTION
## Summary

`pnpm lint` on this repo was slow because:
1. It ran six steps **sequentially** via `&&` when five of them are independent.
2. It ran `tsc --noEmit` **after** `astro check`, duplicating the same TypeScript work that `@astrojs/check` already does on the same `tsconfig.json` include.
3. It used `pnpm run format` (`prettier --write .`) which touches disk on every run, so "lint" was also rewriting files.

CI (`.github/workflows/ci.yml`) already parallelizes the same steps with `&`+`wait`, so this PR just brings local into parity.

## Changes

- **`package.json` `scripts.lint`**:
  - Removed `tsc --noEmit` (astro check is a superset for this tsconfig)
  - `pnpm run format` → `pnpm run format:check` (read-only)
  - Wrapped the remaining five steps in a bash PID-array + wait loop that propagates failure:
    ```
    bash -c 'set -e; pids=(); pnpm run format:check & pids+=($!); eslint --cache . & pids+=($!); markdownlint-cli2 & pids+=($!); pnpm run validate:content & pids+=($!); astro check & pids+=($!); fail=0; for pid in "${pids[@]}"; do wait "$pid" || fail=1; done; exit $fail'
    ```
  - No new devDependency. `npm-run-all2` would prettify this block but was avoided per scope.

- **`tsconfig.json`**: added `"incremental": true` and `"tsBuildInfoFile": "./node_modules/.cache/funailog.tsbuildinfo"`. Note — `@astrojs/check` uses TS language service APIs, not the `tsc --build` pipeline, so this has no measurable effect on `astro check` itself. It's kept because editor-integrated tsc and manual `tsc --noEmit` runs will benefit, and it's a no-op otherwise.

## Timing

Warm cache, same machine state:

| | Wall clock | Note |
|:---|---:|:---|
| Before (`&&` chain) | ~26s | sequential, astro check + tsc duplicating |
| After (parallel) | **~11s** | astro check (~9s) is the new floor |

~58% wall-clock reduction. The remaining floor is set by `astro check` — further wins would require caching its LSP state or folding `validate:content` into its pipeline, both out of scope.

## Failure-propagation test

Induced a type error in `astro.config.ts` (`const __typeErrorTest: number = 'string'`), ran `pnpm run lint`, confirmed:
- astro check reported 2 errors
- The bash wrapper waited for all jobs then exited **1**
- `pnpm run lint` exited with `ELIFECYCLE Command failed with exit code 1`
Reverted the type error. Tree clean.

## Test plan

- [x] `pnpm test` → 39/39 passing (unchanged)
- [x] `pnpm exec astro check` → 0 errors / 0 warnings / 0 hints
- [x] `pnpm run lint` (new) → exit 0 on clean tree
- [x] `pnpm run lint` (new) → exit 1 on induced type error, reverted
- [ ] Merge and verify CI still green (CI was untouched but worth the sanity check)

## Caveats

- **Interleaved output**: with five parallel jobs, stderr/stdout are interleaved in the terminal. Minor readability tradeoff. `npm-run-all2 --aggregate-output` would fix this if ever desired.
- **`bash -c` JSON escaping**: the script is ugly because it has to live on one line in `package.json`. Extracting to `scripts/lint.sh` would be cleaner if this grows.
- **`incremental` tsconfig field is dead code for astro check** (see above). Included intentionally for editor/tsc users; remove in a follow-up if that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)