### PR TITLE
fix(cv): render work entries without roles array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ pnpm-debug.log*
 
 .playwright-mcp
 CV_*
+
+# draft posts (not ready for public)
+src/content/blog/2026/career-reflection-after-reading-dream-distance.mdx
+docs/superpowers/specs/2026-04-09-career-reflection-blog-design.md

--- a/src/lib/cv-generator.tsx
+++ b/src/lib/cv-generator.tsx
@@ -456,7 +456,7 @@ const CVDocument: React.FC<CVDocumentProps> = ({
                 </Text>
               </View>
 
-              {work.roles && work.roles.length > 0 && (
+              {work.roles && work.roles.length > 0 ? (
                 <View style={styles.roleContainer}>
                   {work.roles.map((role, roleIndex) => (
                     <View key={roleIndex} style={styles.roleItem}>
@@ -492,6 +492,18 @@ const CVDocument: React.FC<CVDocumentProps> = ({
                       )}
                     </View>
                   ))}
+                </View>
+              ) : (
+                <View style={styles.roleContainer}>
+                  <View style={styles.roleHeader}>
+                    <Text style={styles.roleTitle}>{work.role}</Text>
+                  </View>
+                  <Text style={styles.description}>{work.description}</Text>
+                  {work.technologies && work.technologies.length > 0 && (
+                    <Text style={styles.technologies}>
+                      {t.technologies}: {work.technologies.join(', ')}
+                    </Text>
+                  )}
                 </View>
               )}
             </View>


### PR DESCRIPTION
## Summary
- `work.roles` を持たない職歴エントリ（ACALL、エクストップテクノロジー）が生成PDFで会社名と期間しか表示されず、`description` と `technologies` が抜け落ちていた問題を修正
- `work.roles` の有無で分岐し、単役職エントリは `work.role` / `work.description` / `work.technologies` を既存の `roleContainer` スタイルで描画するようレンダラを拡張
- 下書き記事のパスを `.gitignore` に追加

## Test plan
- [x] `pnpm cv` で日本語版 PDF を生成し、ACALL / エクストップテクノロジーの description と technologies が表示されることを目視確認
- [x] `pnpm cv:en` で英語版 PDF を生成
- [x] `pnpm exec astro check` で型エラー 0 件を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)