### PR TITLE
chore(cv): refresh profile content for IC/architect positioning

### DIFF
--- a/src/content/portfolio/profile-en.yml
+++ b/src/content/portfolio/profile-en.yml
@@ -1,24 +1,27 @@
 # Portfolio profile data (English) - Updated: 2024-12-21
 profile:
   name: Ryota Ikezawa
-  title: Architect / Software Engineer
+  title: Senior Software Engineer / Architect
   summary: |
-    Software engineer with over 10 years of experience.
-    Joined freee K.K. when the company was ~100 employees, supporting growth to 2,000+ across both
-    technology and organization. Experienced in legacy system remodeling, microservices design,
-    global team management, and 0→1 product launches. Continuously contributed to hiring and incident response.
-    Primarily developing with Ruby, Rails, Go, TypeScript, React, Docker, and Kubernetes.
+    Senior software engineer and architect with 10+ years of experience.
+    At freee K.K. since November 2015, experiencing the company's growth from ~100 to 2,000+ employees.
+    Progressed through data aggregation engineer, tech lead, EM, to current architect.
+    Led legacy system remodeling, microservice design, and multi-tenant data isolation boundary design.
+    Volunteered for an EM role for about a year, then returned to the TL/IC track to take responsibility for technology rather than people.
+    Currently serving as architect on freee's HR/Payroll Integration Platform team.
+    Continuous experience leading and delivering within globally distributed teams (Japan / Philippines).
+    Core stack: Go, TypeScript, Ruby, Rails, React, Kubernetes, gRPC, MySQL, ArgoCD, Datadog.
   avatar: /profile.jpg
 
 workExperience:
   # === freee K.K. (approximately 10 years) ===
   - company: freee K.K.
-    role: Architect / Software Engineer
+    role: Senior Software Engineer / Architect
     period:
       start: '2015-11'
       end: null
     description: |
-      Approximately 10 years at freee K.K., a cloud accounting software provider (100 → 2,000+ employees).
+      10+ years at freee K.K. since November 2015, a cloud accounting software provider (100 → 2,000+ employees).
       Started with data aggregation feature development, progressed through Tech Lead
       and Engineering Manager roles, currently serving as Architect.
       Continuously involved in hiring and incident response.
@@ -34,17 +37,15 @@ workExperience:
       - Docker
       - Kubernetes
     roles:
-      - role: Architect / Software Engineer
+      - role: Senior Software Engineer / Architect
         period:
           start: '2025-01'
           end: null
         project: HR/Payroll Integration Platform
         description: |
-          Serving as Architect in the HR/Payroll Integration Platform team.
-          Driving master data decomposition and microservices design to address a structural issue
-          where customers had to go through unrelated product registration flows in a multi-product environment.
-          Information to be extracted was tightly coupled with the HR product (a large-scale monolith),
-          requiring cross-team coordination with feature owners, auth platform, and QA teams.
+          Main focus: gRPC API redesign and re-delineation of application responsibility boundaries. Driving master data decomposition and microservice design in a multi-product environment where data and auth are tightly coupled with a large-scale monolith.
+          Cross-team coordination with feature owners, auth platform, and QA teams.
+          Also involved in ArgoCD GitOps deployment, cluster upgrade operations, and Datadog (APM / Logs / Infra) observability operations.
         star:
           - situation: |
               In a multi-product environment, customers had to go through unrelated product registration flows.
@@ -58,7 +59,11 @@ workExperience:
               Defined domain boundaries collaboratively with PdM, determining decomposition units based on data usage patterns.
               Considering business constraints (cost/ROI), selected a pragmatic architecture of logical vertical partitioning
               with transaction isolation. Re-planned roadmap multiple times in response to evolving feature requirements.
-              Transitioned from architect to implementation phase, taking ownership of a specific microservice.
+              Main focus: gRPC API redesign and re-delineation of application responsibility boundaries.
+              After transitioning from architect to implementation phase, took ownership of a specific microservice,
+              driving development and operations.
+              Also involved in ArgoCD GitOps deployment, cluster upgrade operations,
+              and ongoing observability operations with Datadog (APM / Logs / Infra).
             result: |
               Established collaboration framework with feature owner teams, improving new feature development productivity.
               Defined technical strategy for incremental decomposition of the large-scale monolith.
@@ -81,11 +86,8 @@ workExperience:
           end: '2024-12'
         project: Employee Portal
         description: |
-          Built a Japan/Philippines hybrid team (4 engineers + 2 QA) from scratch as a playing manager,
-          starting from an undefined planning stage. Wrote 40-50% of the code while delivering service
-          release in 6 months alongside planning. Managed onboarding of mobile app team (2) and
-          contract developers (4) in the latter half. Drove Schema-driven development using
-          OpenAPI Generator, Orval, and TanStack Query to improve development productivity.
+          Built a Japan/Philippines hybrid team (4 engineers + 2 QA) from scratch as a playing manager, writing 40-50% of the code to deliver release in 6 months alongside planning. Later managed onboarding of mobile app team (2) and contract developers (4).
+          Drove Schema-driven development using OpenAPI Generator, Orval, and TanStack Query.
         technologies:
           - Go
           - Ruby
@@ -109,8 +111,6 @@ workExperience:
             action: |
               Managed team operations in English while prioritizing delegation of responsibility and authority.
               Delegated SLI/SLO definition to a team member, including SRE coordination, fostering team autonomy.
-              Navigated cross-cultural people management (performance feedback, promotion/demotion decisions).
-              Promoted high-performing members.
               Drove Schema-driven development using OpenAPI Generator, Orval, and TanStack Query.
             result: |
               Delivered on schedule within 6 months from planning.
@@ -165,10 +165,7 @@ workExperience:
           end: '2023-12'
         project: freee Data Entry Service
         description: |
-          Served as Tech Lead for freee Data Entry Service in the global team.
-          Responsible for development and maintenance of a service that scans paper receipts
-          and converts them to journal entry data. Focused on domain design for Japan-specific
-          tax processing. Contributed to the official release in February 2023.
+          Tech Lead for freee Data Entry Service (paper receipt → journal entry data) in the global team. Focused on domain design for Japan-specific tax processing, contributing to the official release in February 2023.
         star:
           - situation: |
               The service required domain design for Japan-specific tax processing
@@ -182,7 +179,7 @@ workExperience:
               Organized Japan-specific tax processing into domain models, driving design through
               English discussion and knowledge sharing. Documented domain knowledge for team adoption.
             result: |
-              Established development practices for Japan-specific domains in a global team. Contributed to the official release in February 2023.
+              Established development practices for Japan-specific domains in a 7-member global team, contributing to the official release in February 2023.
         links:
           - url: https://adv.freee.co.jp/service/receipt-data-entry
             label: freee Data Entry Service
@@ -205,21 +202,24 @@ workExperience:
           end: '2022-06'
         project: Online Lending Platform
         description: |
-          Led development of the online lending platform at the financial subsidiary (freee Finance Lab Inc.).
-          Supervised 3 engineers and managed the entire service lifecycle.
+          Participated in development of the online lending platform at the financial subsidiary (freee Finance Lab Inc.).
           Navigated specification misalignments with external financial institutions during integration.
+          A parallel effort was prototyping and GTM validation of new lending products.
         star:
           - situation: |
-              Developed an online lending platform at the financial subsidiary.
-              External financial institution integrations required compliance with institution-specific specifications.
+              Participated in the online lending platform development at the financial subsidiary.
+              External financial institution integrations required compliance with institution-specific specifications,
+              while new products were in prototype and GTM validation phase.
             task: |
-              As Tech Lead, supervised 3 engineers and managed the full service lifecycle.
+              Contributed to the development and validation cycles for both the platform and new products.
               Drove specification alignment and implementation with external partners.
             action: |
-              Implemented with consideration for financial institution specifications,
+              Worked through financial institution-specific specifications,
               bridging misalignments with external partners through active communication.
+              For new products, participated in hypothesis testing via customer (GTM) validation.
             result: |
-              Stabilized operations of freee Financing and Cash Flow Management Navi services.
+              Contributed to the foundational development of external financial institution integrations.
+              Some new products were eventually closed based on service status, while accumulating 0→1 hypothesis-testing and external stakeholder coordination experience.
         links:
           - url: https://www.freee.co.jp/financing/
             label: freee Financing
@@ -243,9 +243,7 @@ workExperience:
         project: Data Aggregation Feature
         description: |
           Developed and operated transaction retrieval features via API integration with financial institutions.
-          Participated in multiple integration projects with major banks as PjM and player.
-          Also joined the scraping engine re-architecture project,
-          driving the transition to a multi-layered architecture.
+          Participated in multiple major bank integration projects as PjM and player, and joined the scraping engine re-architecture project driving transition to a multi-layered architecture.
         links:
           - url: https://corp.freee.co.jp/news/freee-amex-api-8458.html
             label: American Express API Integration
@@ -320,6 +318,19 @@ projects:
       - Hono
       - TypeScript
     repository: https://github.com/paveg/hono-problem-details
+
+  - name: hono-cf-access
+    type: oss
+    period:
+      start: '2026-03'
+      end: null
+    description: |
+      Access control middleware for Hono leveraging Cloudflare Workers request.cf properties.
+    techStack:
+      - Hono
+      - TypeScript
+      - Cloudflare Workers
+    repository: https://github.com/paveg/hono-cf-access
 
   - name: hono-webhook-verify
     type: oss
@@ -453,15 +464,15 @@ projects:
 skills:
   - category: Programming Languages
     items:
-      - name: Ruby
-        level: expert
-        yearsOfExperience: 8
-      - name: TypeScript
-        level: expert
-        yearsOfExperience: 5
       - name: Go
         level: advanced
         yearsOfExperience: 3
+      - name: TypeScript
+        level: expert
+        yearsOfExperience: 5
+      - name: Ruby
+        level: expert
+        yearsOfExperience: 8
       - name: Python
         level: intermediate
         yearsOfExperience: 2
@@ -483,12 +494,12 @@ skills:
       - name: Ruby on Rails
         level: expert
         yearsOfExperience: 8
-      - name: Node.js
-        level: advanced
-        yearsOfExperience: 4
       - name: Hono
         level: advanced
         yearsOfExperience: 1
+      - name: Node.js
+        level: advanced
+        yearsOfExperience: 4
 
   - category: Databases
     items:
@@ -499,14 +510,17 @@ skills:
         level: intermediate
         yearsOfExperience: 3
 
-  - category: Infrastructure
+  - category: Infrastructure & Tooling
     items:
-      - name: Docker
-        level: advanced
-        yearsOfExperience: 5
       - name: Kubernetes
         level: advanced
         yearsOfExperience: 4
+      - name: Docker
+        level: advanced
+        yearsOfExperience: 5
+      - name: ArgoCD
+      - name: Datadog
+      - name: gRPC
       - name: AWS
         level: intermediate
         yearsOfExperience: 5

--- a/src/content/portfolio/profile.yml
+++ b/src/content/portfolio/profile.yml
@@ -2,23 +2,27 @@
 profile:
   name: Ryota Ikezawa
   nameKana: イケザワ リョウタ
-  title: Architect / Software Engineer
+  title: Senior Software Engineer / Architect
   summary: |
-    10年以上の経験を持つソフトウェアエンジニア。
-    freee株式会社に100名規模の時期から在籍し、2000名規模への成長を技術・組織の両面で支える。
-    レガシーシステムのリモデリング・マイクロサービス設計から、グローバルチームのマネジメント、0→1のプロダクト立ち上げまで幅広く経験。
-    採用、障害対応にも継続的に貢献。Ruby, Rails, Go, TypeScript, React, Docker, Kubernetesを中心に開発。
+    10年以上の経験を持つシニアソフトウェアエンジニア / アーキテクト。
+    freee株式会社に2015年11月より在籍し、100名から2000名規模への成長期を経験。
+    データ集約機能の開発からテックリード、EM、アーキテクトまで役割を広げてきた。
+    レガシーシステムのリモデリング・マイクロサービス設計・マルチテナント環境でのデータ分離境界設計を主導。
+    EMロールも手を挙げて約1年経験した後、人より技術に責任を持つTL/ICトラックに復帰。
+    現在はアーキテクトとして人事労務統合基盤の設計・実装を担当。
+    日本・フィリピン混成のグローバルチームでの開発・リードを継続的に経験。
+    Core stack: Go, TypeScript, Ruby, Rails, React, Kubernetes, gRPC, MySQL, ArgoCD, Datadog.
   avatar: /profile.jpg
 
 workExperience:
   # === freee株式会社（約10年在籍） ===
   - company: freee株式会社
-    role: Architect / Software Engineer
+    role: Senior Software Engineer / Architect
     period:
       start: '2015-11'
       end: null
     description: |
-      クラウド会計ソフトを提供するfreee株式会社にて約10年在籍（100名→2000名規模の成長期）。
+      クラウド会計ソフトを提供するfreee株式会社にて2015年11月より10年以上在籍（100名→2000名規模の成長期）。
       データ集約機能の開発からスタートし、テックリード、エンジニアリングマネージャーを経て現在はアーキテクトとして従事。
       採用活動、障害対応にも継続的に関与。
       初期から在籍していたことで、負債化したサービスのリモデリング・リアーキテクチャに複数回関与。
@@ -34,16 +38,15 @@ workExperience:
       - Kubernetes
     # 役職変遷
     roles:
-      - role: Architect / Software Engineer
+      - role: Senior Software Engineer / Architect
         period:
           start: '2025-01'
           end: null
         project: 人事労務統合基盤
         description: |
-          人事労務統合基盤チームにてアーキテクトとして従事。
-          マルチプロダクト環境の構造的課題に対し、マスタデータの分割・マイクロサービス設計を推進。
-          基盤から切り出す情報が人事労務プロダクト（大規模モノリス）に密結合しており、
-          各機能のオーナーチーム・認証基盤・品質チームとの横断的な調整・設計にも関与。
+          gRPC API 再設計とアプリケーション責任境界の仕切り直しをメインに、マスタデータ分割・マイクロサービス設計を推進。
+          大規模モノリスに密結合する基盤情報について、各機能オーナー・認証基盤・品質チーム横断の調整にも関与。
+          ArgoCD GitOps デプロイ・クラスタアップグレード、Datadog (APM/Logs/Infra) による observability 運用にも継続関与。
         technologies:
           - Go
           - Ruby
@@ -70,7 +73,10 @@ workExperience:
               PdMと壁打ちしながらドメイン境界を定義し、データの利用形態に基づいて分割単位を決定。
               ビジネス制約（コスト・ROI）を踏まえ、論理的垂直分割によるトランザクション分離という
               現実的なアーキテクチャを選定。並走する機能企画の変更に応じてロードマップを複数回再策定。
-              アーキテクトから実装フェーズに移行後、特定マイクロサービスのオーナーシップを持ち開発を推進。
+              メイン業務は gRPC API の再設計とアプリケーション責任境界の仕切り直しで、
+              アーキテクトから実装フェーズに移行後は特定マイクロサービスのオーナーシップを持ち開発・運用を推進。
+              ArgoCD による GitOps デプロイやクラスタアップグレードを含む運用タスクにも関与し、
+              Datadog (APM / Logs / Infra) を用いた observability 運用を継続的に実施。
             result: |
               各機能オーナーチームとの連携体制を構築し、新機能開発における生産性向上の基盤を整備。
               大規模モノリスに対する段階的分割の技術戦略を確立。
@@ -108,8 +114,6 @@ workExperience:
             action: |
               英語でのチーム運営を実施しながら、メンバーへの責任・権限移譲を重視。
               SLI/SLO定義をメンバーに委任しSREとの連携も担わせることでチームの自律性を促進。
-              多文化環境でのピープルマネジメント（評価フィードバック、昇格・降格の判断）にも対峙。
-              成長したメンバーのプロモーションも実施。
               OpenAPI Generator、Orval、TanStack QueryによるSchema駆動開発を推進。
             result: |
               企画並走で6ヶ月のリリースを予定通り達成。
@@ -194,7 +198,7 @@ workExperience:
               日本固有の税務処理をドメインモデルとして整理し、英語で共有・議論しながら設計を推進。
               ドメイン知識のドキュメント化とチーム内への浸透を実施。
             result: |
-              グローバルチームでの日本特有ドメインの開発体制を確立し、2023年2月の正式版リリースに貢献。
+              グローバルチーム（7名）での日本特有ドメインの開発体制を確立し、2023年2月の正式版リリースに貢献。
 
       - role: Software Engineer / Tech Lead
         period:
@@ -202,9 +206,9 @@ workExperience:
           end: '2022-06'
         project: オンラインレンディングプラットフォーム
         description: |
-          金融子会社にてオンラインレンディングプラットフォームの開発をリード。
-          3名のエンジニアを監督し、サービスライフサイクル全体を管理。外部金融機関との連携において、
-          仕様の認識不一致を埋めながら実装を推進。
+          金融子会社にてオンラインレンディングプラットフォームの開発に参画。
+          外部金融機関との連携において、仕様の認識不一致を埋めながら実装を推進。
+          新規プロダクトのプロトタイプ開発と GTM 検証も並行で進めるフェーズだった。
         links:
           - url: https://www.freee.co.jp/financing/
             label: freee資金調達
@@ -222,16 +226,19 @@ workExperience:
           - Docker
         star:
           - situation: |
-              金融子会社にてオンラインレンディングプラットフォームを開発。
-              外部金融機関との連携が必要であり、金融機関固有の仕様への対応が求められた。
+              金融子会社にてオンラインレンディングプラットフォームの開発に参画。
+              外部金融機関との連携を前提としつつ、新規プロダクトのプロトタイプ開発と
+              GTM 検証を並行で進めるフェーズだった。
             task: |
-              テックリードとして3名のエンジニアを監督し、サービスライフサイクル全体を管理。
-              外部連携先との仕様調整と実装を推進。
+              プラットフォームと新規プロダクトの開発・検証サイクルに貢献。
+              外部連携先との仕様調整・実装も推進。
             action: |
-              金融機関の仕様を考慮した実装を行い、外部連携先との認識不一致を
-              コミュニケーションを通じて埋めながら開発を推進。
+              金融機関固有の仕様への対応を進めつつ、
+              外部連携先との認識不一致をコミュニケーションを通じて埋めながら開発を推進。
+              新規プロダクトについては顧客検証 (GTM) を通じた仮説検証にも携わった。
             result: |
-              freee資金調達・資金繰り改善ナビのサービス運用を安定化。
+              外部金融機関連携の基盤開発に貢献。
+              新規プロダクトはサービス状況を踏まえクローズに至ったが、0→1 の仮説検証プロセスと外部ステークホルダー調整の経験を蓄積。
 
       - role: Software Engineer
         period:
@@ -314,6 +321,20 @@ projects:
       - Hono
       - TypeScript
     repository: https://github.com/paveg/hono-problem-details
+
+  - name: hono-cf-access
+    type: oss
+    period:
+      start: '2026-03'
+      end: null
+    description: |
+      Cloudflare Workers の request.cf プロパティを利用した
+      Hono 向けアクセスコントロールミドルウェア。
+    techStack:
+      - Hono
+      - TypeScript
+      - Cloudflare Workers
+    repository: https://github.com/paveg/hono-cf-access
 
   - name: hono-webhook-verify
     type: oss
@@ -447,15 +468,15 @@ projects:
 skills:
   - category: Programming Languages
     items:
-      - name: Ruby
-        level: expert
-        yearsOfExperience: 8
-      - name: TypeScript
-        level: expert
-        yearsOfExperience: 5
       - name: Go
         level: advanced
         yearsOfExperience: 3
+      - name: TypeScript
+        level: expert
+        yearsOfExperience: 5
+      - name: Ruby
+        level: expert
+        yearsOfExperience: 8
       - name: Python
         level: intermediate
         yearsOfExperience: 2
@@ -477,12 +498,12 @@ skills:
       - name: Ruby on Rails
         level: expert
         yearsOfExperience: 8
-      - name: Node.js
-        level: advanced
-        yearsOfExperience: 4
       - name: Hono
         level: advanced
         yearsOfExperience: 1
+      - name: Node.js
+        level: advanced
+        yearsOfExperience: 4
 
   - category: Databases
     items:
@@ -493,14 +514,17 @@ skills:
         level: intermediate
         yearsOfExperience: 3
 
-  - category: Infrastructure
+  - category: Infrastructure & Tooling
     items:
-      - name: Docker
-        level: advanced
-        yearsOfExperience: 5
       - name: Kubernetes
         level: advanced
         yearsOfExperience: 4
+      - name: Docker
+        level: advanced
+        yearsOfExperience: 5
+      - name: ArgoCD
+      - name: Datadog
+      - name: gRPC
       - name: AWS
         level: intermediate
         yearsOfExperience: 5


### PR DESCRIPTION
## Summary
- 池澤さんの現時点のポジション（Application Engineer / Architect, IC トラック）に合わせて profile.yml / profile-en.yml を全面刷新
- 誇張表現の訂正: レンディングロールを「リード」→「参画」、EM action から評価・昇降格判断を削除、クローズ判断の agency を passive に書き換え
- 現職 Architect ロールの中身を更新: メイン業務を **gRPC API 再設計とアプリケーション責任境界の仕切り直し** と明記、ArgoCD/Datadog は運用側として記述
- タイトルを \`Senior Software Engineer / Architect\` に統一 (profile / work / 現職 role)
- Skills 再編: Programming Languages の先頭を Go に、\`Infrastructure & Tooling\` に ArgoCD / Datadog / gRPC を追加
- OSS projects に \`hono-cf-access\` を追加
- **2 ページ制約**: CV_Ryota_Ikezawa_EN.pdf が 3 ページにはみ出していたため各 description を圧縮、JA/EN とも 2 A4 ページに収まることを確認

## What this PR does NOT do
- STAR の \`action\` / \`task\` / \`situation\` フィールドは CV PDF でも portfolio ページでも描画されていないため、編集しても見た目に影響しません。ソースの一貫性のため一部は更新しましたが、本質的な訂正は description 側に入れています
- EN PDF に残っている \`Cloudflare\`→\`Cloudfare\`, \`CoffeeScript\`→\`CofeeScript\`, \`specific\`→\`specifc\`, \`flows\`→\`fows\` などの文字欠けは Noto Sans JP のリガチャ描画バグで、source のタイポではありません。\`cv-generator.tsx:62-74\` のフォント登録修正が必要で、別 PR で対応

## Test plan
- [x] \`pnpm cv\` / \`pnpm cv:en\` で PDF 生成成功
- [x] \`pdfinfo\` で JA / EN とも \`Pages: 2\` を確認
- [x] 生成 PDF を目視確認し、Architect description に gRPC API 再設計・ArgoCD 運用・Datadog 運用が反映されていることを確認
- [x] レンディング STAR の passive 表現と 2-bullet 形式を確認
- [x] データ化サービス result が 7 名 global team を含む 1 bullet に統合されていることを確認
- [x] \`pnpm exec astro check\` で型エラー 0 件
- [ ] portfolio ページ (https://funailog.com/portfolio) でも同内容が反映されることを本番デプロイ後に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)