### PR TITLE
feat(layout): apply BudouX phrase-aware line wrapping site-wide

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -11,6 +11,7 @@ import { h } from 'hastscript';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeMermaid from 'rehype-mermaid';
 
+import rehypeBudoux from './src/lib/rehype-budoux';
 import remarkLink from './src/lib/remark-link';
 import { remarkReadingTime } from './src/lib/remark-reading-time';
 
@@ -92,6 +93,7 @@ export default defineConfig({
           }),
         },
       ],
+      rehypeBudoux,
     ],
   },
   site: 'https://www.funailog.com',

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@tailwindcss/vite": "4.2.1",
     "astro": "^6.1.4",
     "astro-embed": "0.12.0",
+    "budoux": "0.8.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "d3-hierarchy": "3.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       astro-embed:
         specifier: 0.12.0
         version: 0.12.0(astro@6.1.4(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+      budoux:
+        specifier: 0.8.1
+        version: 0.8.1
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1156,89 +1159,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1457,66 +1476,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1671,24 +1703,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -2057,6 +2093,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
@@ -2255,6 +2295,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -2282,6 +2325,13 @@ packages:
     resolution: {integrity: sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  budoux@0.8.1:
+    resolution: {integrity: sha512-UM2Gsqlcr3DRV7cbuYEN3UBDvmqSPaN/wTz4rI93v0UiCqAZDd5vjjFHUpz3+SAEHYcR2QkovMyCZ++q8UWAcQ==}
+    hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2418,6 +2468,10 @@ packages:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
@@ -2508,6 +2562,9 @@ packages:
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -2814,6 +2871,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   electron-to-chromium@1.5.260:
     resolution: {integrity: sha512-ov8rBoOBhVawpzdre+Cmz4FB+y66Eqrk6Gwqd8NGxuhv99GQ8XqMAr351KEkOt7gukXWDg6gJWEMKgL2RLMPtA==}
 
@@ -2846,6 +2906,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   environment@1.1.0:
@@ -3265,6 +3329,14 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -3335,6 +3407,18 @@ packages:
     resolution: {integrity: sha512-oB4vkQGqlMl682wL1IlWd02tXCbquGWM4voPEI85QmNKCaw8zGTm1f1rubFgkg3Eli2PtKlFgrnmUqasbQWlkw==}
     engines: {node: '>=20'}
 
+  google-artifactregistry-auth@3.5.0:
+    resolution: {integrity: sha512-SIvVBPjVr0KvYFEJEZXKfELt8nvXwTKl6IHyOT7pTHBlS8Ej2UuTOJeKWYFim/JztSjUyna9pKQxa3VhTA12Fg==}
+    hasBin: true
+
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
 
@@ -3344,6 +3428,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
@@ -3464,11 +3552,18 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   htmlparser2@9.1.0:
     resolution: {integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
@@ -3687,6 +3782,10 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3769,6 +3868,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -3799,6 +3901,12 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   katex@0.16.27:
     resolution: {integrity: sha512-aeQoDkuRWSqQN6nSvVCEFvfXdqo1OQiCmmW1kc9xSdjutPv7BGO7pqY9sQRJpMOGrEdfDgF2TfRXe5eUAD2Waw==}
@@ -3904,48 +4012,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.31.1:
     resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3985,6 +4101,15 @@ packages:
 
   linebreak@1.1.0:
     resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+
+  linkedom@0.18.12:
+    resolution: {integrity: sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
@@ -4345,6 +4470,15 @@ packages:
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
@@ -5248,6 +5382,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -5352,6 +5489,9 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
   uint8arrays@3.0.0:
     resolution: {integrity: sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==}
@@ -5512,6 +5652,10 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
   vfile-location@5.0.3:
@@ -5755,6 +5899,12 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
@@ -7832,6 +7982,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -8270,6 +8422,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  bignumber.js@9.3.1: {}
+
   boolbase@1.0.0: {}
 
   boxen@8.0.1:
@@ -8311,6 +8465,18 @@ snapshots:
       electron-to-chromium: 1.5.260
       node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.28.0)
+
+  budoux@0.8.1:
+    dependencies:
+      commander: 14.0.3
+      google-artifactregistry-auth: 3.5.0
+      linkedom: 0.18.12
+    transitivePeerDependencies:
+      - canvas
+      - encoding
+      - supports-color
+
+  buffer-equal-constant-time@1.0.1: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -8436,6 +8602,8 @@ snapshots:
 
   commander@13.1.0: {}
 
+  commander@14.0.3: {}
+
   commander@7.2.0: {}
 
   commander@8.3.0: {}
@@ -8515,6 +8683,8 @@ snapshots:
   csso@5.0.5:
     dependencies:
       css-tree: 2.2.1
+
+  cssom@0.5.0: {}
 
   csstype@3.2.3: {}
 
@@ -8840,6 +9010,10 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   electron-to-chromium@1.5.260: {}
 
   emmet@2.4.11:
@@ -8865,6 +9039,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   environment@1.1.0: {}
 
@@ -9569,6 +9745,26 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  gaxios@6.7.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  gcp-metadata@6.1.1:
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -9653,6 +9849,29 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.3.0
 
+  google-artifactregistry-auth@3.5.0:
+    dependencies:
+      google-auth-library: 9.15.1
+      js-yaml: 4.1.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-auth-library@9.15.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-logging-utils@0.0.2: {}
+
   gopd@1.0.1:
     dependencies:
       get-intrinsic: 1.2.4
@@ -9660,6 +9879,14 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   h3@1.15.11:
     dependencies:
@@ -9892,6 +10119,13 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   htmlparser2@9.1.0:
     dependencies:
       domelementtype: 2.3.0
@@ -9900,6 +10134,13 @@ snapshots:
       entities: 4.5.0
 
   http-cache-semantics@4.2.0: {}
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-signals@5.0.0: {}
 
@@ -10096,6 +10337,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-stream@2.0.1: {}
+
   is-stream@3.0.0: {}
 
   is-string@1.0.7:
@@ -10175,6 +10418,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -10199,6 +10446,17 @@ snapshots:
       array.prototype.flat: 1.3.2
       object.assign: 4.1.5
       object.values: 1.2.0
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   katex@0.16.27:
     dependencies:
@@ -10341,6 +10599,14 @@ snapshots:
     dependencies:
       base64-js: 0.0.8
       unicode-trie: 2.0.0
+
+  linkedom@0.18.12:
+    dependencies:
+      css-select: 5.2.2
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.1.0
+      uhyphen: 0.2.0
 
   linkify-it@5.0.0:
     dependencies:
@@ -11027,6 +11293,10 @@ snapshots:
       '@types/nlcst': 2.0.3
 
   node-fetch-native@1.6.7: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-mock-http@1.0.4: {}
 
@@ -12112,6 +12382,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tr46@0.0.3: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -12237,6 +12509,8 @@ snapshots:
   uc.micro@2.1.0: {}
 
   ufo@1.6.3: {}
+
+  uhyphen@0.2.0: {}
 
   uint8arrays@3.0.0:
     dependencies:
@@ -12387,6 +12661,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@11.1.0: {}
+
+  uuid@9.0.1: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -12576,6 +12852,13 @@ snapshots:
   vscode-uri@3.1.0: {}
 
   web-namespaces@2.0.1: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.0.2:
     dependencies:

--- a/src/components/AffiliateCard.astro
+++ b/src/components/AffiliateCard.astro
@@ -1,6 +1,7 @@
 ---
 import { getEntry } from 'astro:content';
 
+import Budoux from '@/components/Budoux.astro';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 
@@ -137,13 +138,19 @@ if (other) {
       {/* 商品情報 */}
       <div class="flex flex-1 flex-col">
         <CardHeader className="pb-2">
-          <h3 class="text-foreground m-0 line-clamp-2 text-base font-medium">
-            {title}
+          <h3
+            class="text-foreground m-0 line-clamp-2 text-base font-medium"
+            data-budoux
+          >
+            <Budoux text={title} />
           </h3>
           {
             description && (
-              <p class="text-muted-foreground m-0 line-clamp-2 text-sm">
-                {description}
+              <p
+                class="text-muted-foreground m-0 line-clamp-2 text-sm"
+                data-budoux
+              >
+                <Budoux text={description} />
               </p>
             )
           }

--- a/src/components/Budoux.astro
+++ b/src/components/Budoux.astro
@@ -1,0 +1,18 @@
+---
+import { loadDefaultJapaneseParser } from 'budoux';
+
+interface Props {
+  text: string;
+}
+
+const { text } = Astro.props;
+
+const segments = loadDefaultJapaneseParser().parse(text);
+---
+
+{
+  segments.flatMap((value, index) => [
+    ...(index > 0 ? [<wbr />] : []),
+    <Fragment>{value}</Fragment>,
+  ])
+}

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,7 @@
 ---
 import { getEntry } from 'astro:content';
 
+import Budoux from '@/components/Budoux.astro';
 import { defaultLang } from '@/i18n/ui';
 import { useTranslations } from '@/i18n/utils';
 
@@ -20,11 +21,11 @@ const startYear = 2023;
     {/* Column 1: Site identity */}
     <div class="space-y-2">
       <p class="text-foreground font-medium">funailog.com</p>
-      <p class="hidden leading-relaxed sm:block">
-        {t('footer.description')}
+      <p class="hidden leading-relaxed sm:block" data-budoux>
+        <Budoux text={t('footer.description')} />
       </p>
-      <p class="leading-relaxed sm:hidden">
-        {t('footer.descriptionShort')}
+      <p class="leading-relaxed sm:hidden" data-budoux>
+        <Budoux text={t('footer.descriptionShort')} />
       </p>
     </div>
 

--- a/src/components/InfinitePostList.tsx
+++ b/src/components/InfinitePostList.tsx
@@ -4,7 +4,15 @@ import {
   MagnifyingGlassIcon,
   ReloadIcon,
 } from '@radix-ui/react-icons';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { loadDefaultJapaneseParser } from 'budoux';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { Badge } from '@/components/ui/badge';
 import { defaultLang } from '@/i18n/ui';
@@ -13,6 +21,7 @@ import { filterTags } from '@/lib/tags';
 import { cn, formatDateEn } from '@/lib/utils';
 
 const t = useTranslations(defaultLang);
+const budouxParser = loadDefaultJapaneseParser();
 
 export type SerializedPost = {
   type: 'blog';
@@ -64,8 +73,16 @@ function PostItem({ post }: { post: SerializedPost }) {
         </span>
       </div>
       <a href={post.url} className="block pt-1">
-        <h2 className="font-heading text-foreground group-hover:text-link line-clamp-2 text-base break-words transition-colors duration-200 md:text-lg">
-          {post.title}
+        <h2
+          className="font-heading text-foreground group-hover:text-link line-clamp-2 text-base transition-colors duration-200 md:text-lg"
+          data-budoux
+        >
+          {budouxParser
+            .parse(post.title)
+            .flatMap((segment, i) => [
+              ...(i > 0 ? [<wbr key={`wbr-${i}`} />] : []),
+              <Fragment key={`seg-${i}`}>{segment}</Fragment>,
+            ])}
         </h2>
       </a>
       {tags.length > 0 && (

--- a/src/components/NotFound.astro
+++ b/src/components/NotFound.astro
@@ -1,4 +1,5 @@
 ---
+import Budoux from '@/components/Budoux.astro';
 import ButtonLink from '@/components/ButtonLink.astro';
 import { useTranslations } from '@/i18n/utils';
 
@@ -6,7 +7,7 @@ const t = useTranslations('ja');
 ---
 
 <div class="py-12 text-center">
-  <h2>{t('content.notfound')}</h2>
+  <h2 data-budoux><Budoux text={t('content.notfound')} /></h2>
 
   <ButtonLink
     href="/blog"

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,6 +1,7 @@
 ---
 import type { UnifiedPost } from '@/types/unified-post';
 
+import Budoux from '@/components/Budoux.astro';
 import { formatDateEn } from '@/lib/utils';
 
 export type Props = {
@@ -57,12 +58,18 @@ const hasDistinctUpdate = !!lastUpdatedOnly && lastUpdatedOnly !== dateOnly;
                 </time>
               )}
             </div>
-            <h3 class="font-heading text-foreground group-hover:text-link line-clamp-2 text-lg transition-colors duration-150">
-              {post.title}
+            <h3
+              class="font-heading text-foreground group-hover:text-link line-clamp-2 text-lg transition-colors duration-150"
+              data-budoux
+            >
+              <Budoux text={post.title} />
             </h3>
             {post.description && (
-              <p class="text-muted-foreground mt-2 line-clamp-2 text-sm">
-                {post.description}
+              <p
+                class="text-muted-foreground mt-2 line-clamp-2 text-sm"
+                data-budoux
+              >
+                <Budoux text={post.description} />
               </p>
             )}
           </div>
@@ -90,8 +97,11 @@ const hasDistinctUpdate = !!lastUpdatedOnly && lastUpdatedOnly !== dateOnly;
                 </time>
               )}
             </div>
-            <h3 class="font-heading text-foreground group-hover:text-link transition-colors duration-150">
-              {post.title}
+            <h3
+              class="font-heading text-foreground group-hover:text-link transition-colors duration-150"
+              data-budoux
+            >
+              <Budoux text={post.title} />
             </h3>
           </div>
         </div>

--- a/src/components/article/RelatedArticles.astro
+++ b/src/components/article/RelatedArticles.astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 
+import Budoux from '@/components/Budoux.astro';
 import { formatDateEn } from '@/lib/utils';
 
 export type Props = {
@@ -18,8 +19,11 @@ const { posts } = Astro.props;
         {posts.map((post) => (
           <li>
             <a href={`/blog/${post.id}`} class="group block">
-              <span class="font-heading text-foreground group-hover:text-link text-sm transition-colors">
-                {post.data.title}
+              <span
+                class="font-heading text-foreground group-hover:text-link text-sm transition-colors"
+                data-budoux
+              >
+                <Budoux text={post.data.title} />
               </span>
               <span class="font-code text-muted-foreground ml-2 text-xs">
                 {formatDateEn(post.data.published)}

--- a/src/components/portfolio/CVExportButton.astro
+++ b/src/components/portfolio/CVExportButton.astro
@@ -3,6 +3,8 @@ import { CodeIcon } from '@radix-ui/react-icons';
 
 import type { SupportedLang } from '@/config/site';
 
+import Budoux from '@/components/Budoux.astro';
+
 interface Props {
   lang?: SupportedLang;
 }
@@ -31,13 +33,19 @@ const t = texts[lang];
 {
   isDev && (
     <div class="border-border rounded-md border border-dashed p-4">
-      <p class="text-foreground mb-2 text-sm font-medium">{t.title}</p>
-      <p class="text-muted-foreground mb-3 text-sm">{t.description}</p>
+      <p class="text-foreground mb-2 text-sm font-medium" data-budoux>
+        <Budoux text={t.title} />
+      </p>
+      <p class="text-muted-foreground mb-3 text-sm" data-budoux>
+        <Budoux text={t.description} />
+      </p>
       <div class="bg-muted flex items-center gap-2 rounded-md p-3 font-mono text-sm">
         <CodeIcon className="text-muted-foreground size-4 shrink-0" />
         <code class="text-foreground">pnpm cv</code>
       </div>
-      <p class="text-muted-foreground/80 mt-2 text-xs">{t.note}</p>
+      <p class="text-muted-foreground/80 mt-2 text-xs" data-budoux>
+        <Budoux text={t.note} />
+      </p>
     </div>
   )
 }

--- a/src/components/portfolio/CollapsibleRoles.tsx
+++ b/src/components/portfolio/CollapsibleRoles.tsx
@@ -1,6 +1,9 @@
-import { useState } from 'react';
+import { loadDefaultJapaneseParser } from 'budoux';
+import { Fragment, useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
+
+const budouxParser = loadDefaultJapaneseParser();
 
 interface RoleLink {
   url: string;
@@ -140,8 +143,16 @@ export function CollapsibleRoles({
               </span>
 
               {/* Role Description */}
-              <p className="text-muted-foreground mt-1.5 text-xs leading-relaxed sm:text-sm">
-                {role.description}
+              <p
+                className="text-muted-foreground mt-1.5 text-xs leading-relaxed sm:text-sm"
+                data-budoux
+              >
+                {budouxParser
+                  .parse(role.description)
+                  .flatMap((segment, i) => [
+                    ...(i > 0 ? [<wbr key={`wbr-${i}`} />] : []),
+                    <Fragment key={`seg-${i}`}>{segment}</Fragment>,
+                  ])}
               </p>
 
               {/* Role Links */}

--- a/src/components/portfolio/ProfileSection.astro
+++ b/src/components/portfolio/ProfileSection.astro
@@ -1,6 +1,7 @@
 ---
 import type { Profile } from '@/schemas/portfolio-collection';
 
+import Budoux from '@/components/Budoux.astro';
 import { Badge } from '@/components/ui/badge';
 
 interface Props {
@@ -43,7 +44,8 @@ const { profile } = Astro.props;
   </div>
   <p
     class="bg-muted/30 text-muted-foreground rounded-lg p-3 text-xs leading-relaxed sm:p-4 sm:text-sm"
+    data-budoux
   >
-    {profile.summary}
+    <Budoux text={profile.summary} />
   </p>
 </section>

--- a/src/components/portfolio/ProjectsSection.astro
+++ b/src/components/portfolio/ProjectsSection.astro
@@ -4,6 +4,7 @@ import { ExternalLinkIcon, GitHubLogoIcon } from '@radix-ui/react-icons';
 import type { SupportedLang } from '@/config/site';
 import type { Project } from '@/schemas/portfolio-collection';
 
+import Budoux from '@/components/Budoux.astro';
 import { Badge } from '@/components/ui/badge';
 import { useTranslations } from '@/i18n/utils';
 
@@ -83,8 +84,11 @@ const collapseLabel = lang === 'en' ? 'Collapse' : '折りたたむ';
               )}
             </div>
           </div>
-          <p class="text-muted-foreground text-xs leading-relaxed sm:text-sm">
-            {project.description}
+          <p
+            class="text-muted-foreground text-xs leading-relaxed sm:text-sm"
+            data-budoux
+          >
+            <Budoux text={project.description} />
           </p>
           <div class="flex flex-wrap gap-1 sm:gap-1.5">
             {project.techStack.slice(0, 5).map((tech) => (

--- a/src/components/portfolio/WorkExperienceSection.astro
+++ b/src/components/portfolio/WorkExperienceSection.astro
@@ -4,6 +4,7 @@ import { CollapsibleRoles } from './CollapsibleRoles';
 import type { SupportedLang } from '@/config/site';
 import type { WorkExperience } from '@/schemas/portfolio-collection';
 
+import Budoux from '@/components/Budoux.astro';
 import { Badge } from '@/components/ui/badge';
 import { useTranslations } from '@/i18n/utils';
 
@@ -104,8 +105,11 @@ const COLLAPSIBLE_THRESHOLD = 3;
               </div>
 
               {/* Company Summary */}
-              <p class="text-muted-foreground mt-1 text-xs leading-relaxed sm:mt-1.5 sm:text-sm">
-                {work.description}
+              <p
+                class="text-muted-foreground mt-1 text-xs leading-relaxed sm:mt-1.5 sm:text-sm"
+                data-budoux
+              >
+                <Budoux text={work.description} />
               </p>
 
               {/* Technologies (company level) - shown only for companies without roles */}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import '@/styles/tokens.css';
+import '@/styles/budoux.css';
 
 import { getEntry } from 'astro:content';
 

--- a/src/lib/rehype-budoux.ts
+++ b/src/lib/rehype-budoux.ts
@@ -1,0 +1,54 @@
+import { loadDefaultJapaneseParser } from 'budoux';
+import { h } from 'hastscript';
+import { visit } from 'unist-util-visit';
+
+import type { HTMLProcessingParser } from 'budoux';
+import type { Root } from 'hast';
+import type { Plugin } from 'unified';
+
+interface Options {
+  excludeTagNames?: string[];
+}
+
+const defaultExcludeTagNames = ['pre', 'code'];
+
+let parser: HTMLProcessingParser | null = null;
+
+const rehypeBudoux: Plugin<[Options?], Root> = ({
+  excludeTagNames = defaultExcludeTagNames,
+}: Options = {}) => {
+  return (tree) => {
+    visit(tree, 'text', (node, index, parent) => {
+      if (
+        index === undefined ||
+        !parent ||
+        parent.type !== 'element' ||
+        excludeTagNames.includes(parent.tagName) ||
+        node.value.trim().length === 0
+      ) {
+        return;
+      }
+
+      parser ??= loadDefaultJapaneseParser();
+
+      const segments = parser.parse(node.value);
+      if (segments.length <= 1) {
+        return;
+      }
+
+      const replacement = segments.flatMap((value, i) => [
+        ...(i > 0 ? [h('wbr')] : []),
+        { type: 'text' as const, value },
+      ]);
+
+      parent.children.splice(index, 1, ...replacement);
+
+      parent.properties = {
+        ...parent.properties,
+        dataBudoux: true,
+      };
+    });
+  };
+};
+
+export default rehypeBudoux;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,4 +1,5 @@
 ---
+import Budoux from '@/components/Budoux.astro';
 import Link from '@/components/Link.astro';
 import { defaultLang } from '@/i18n/ui';
 import { useTranslations } from '@/i18n/utils';
@@ -21,9 +22,9 @@ const t = useTranslations(defaultLang);
   ]}
 >
   <div class="mx-auto py-12 text-center">
-    <h1>{t('404.title')}</h1>
-    <p class="text-secondary-foreground text-sm">
-      {t('404.description')}
+    <h1 data-budoux><Budoux text={t('404.title')} /></h1>
+    <p class="text-secondary-foreground text-sm" data-budoux>
+      <Budoux text={t('404.description')} />
     </p>
     <p>
       <Link href="/">{t('404.back')}</Link>

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -7,6 +7,7 @@ import {
   type CollectionEntry,
 } from 'astro:content';
 
+import Budoux from '@/components/Budoux.astro';
 import Figure from '@/components/Figure.astro';
 import Link from '@/components/Link.astro';
 import { defaultLang } from '@/i18n/ui';
@@ -76,7 +77,7 @@ const homeUrl = new URL('/', site).toString();
   ]}
 >
   <article>
-    <h1>{page.data.title}</h1>
+    <h1 data-budoux><Budoux text={page.data.title} /></h1>
     <Content components={components} />
   </article>
 </Layout>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -12,6 +12,7 @@ import ArticleHeader from '@/components/article/ArticleHeader.astro';
 import ArticleTOC from '@/components/article/ArticleTOC.astro';
 import ReadingProgress from '@/components/article/ReadingProgress.astro';
 import RelatedArticles from '@/components/article/RelatedArticles.astro';
+import Budoux from '@/components/Budoux.astro';
 import Figure from '@/components/Figure.astro';
 import Link from '@/components/Link.astro';
 import Image from '@/components/markdown/Image.astro';
@@ -93,8 +94,8 @@ const relatedPosts = getRelatedPosts(post, publishedPosts);
   <div>
     {/* Header section: full-width, centered */}
     <header class="mb-6">
-      <h1 class="font-heading text-center [text-wrap:wrap] [word-break:normal]">
-        {post.data.title}
+      <h1 class="font-heading text-center [text-wrap:wrap]" data-budoux>
+        <Budoux text={post.data.title} />
       </h1>
       <ArticleHeader post={post} minRead={remarkPluginFrontmatter.minRead} />
       <Image

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, getEntry } from 'astro:content';
 
+import Budoux from '@/components/Budoux.astro';
 import PostCard from '@/components/PostCard.astro';
 import { defaultLang } from '@/i18n/ui';
 import { useTranslations, generateHreflangs } from '@/i18n/utils';
@@ -53,13 +54,15 @@ const otherPosts = recentPosts.slice(1);
       </div>
       <div class="space-y-3">
         <h1 class="font-heading text-2xl md:text-3xl">{t('main.title')}</h1>
-        <p class="text-muted-foreground text-lg font-medium">
-          {t('index.tagline')}
+        <p class="text-muted-foreground text-lg font-medium" data-budoux>
+          <Budoux text={t('index.tagline')} />
         </p>
-        <p class="text-muted-foreground max-w-lg text-sm leading-relaxed">
-          {t('index.heroLine1')}<br class="hidden sm:inline" />{
-            t('index.heroLine2')
-          }
+        <p
+          class="text-muted-foreground max-w-lg text-sm leading-relaxed"
+          data-budoux
+        >
+          <Budoux text={t('index.heroLine1')} /><br class="hidden sm:inline" />
+          <Budoux text={t('index.heroLine2')} />
         </p>
       </div>
     </section>

--- a/src/styles/budoux.css
+++ b/src/styles/budoux.css
@@ -1,0 +1,5 @@
+/* BudouX: keep Japanese phrases together at <wbr> boundaries */
+[data-budoux] {
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## Summary

Apply Google BudouX phrase-aware Japanese line breaking site-wide. Wrapping now respects Japanese phrase boundaries instead of breaking at arbitrary CJK characters. Implemented in three layers:

- **Phase 1 — MDX body**: build-time rehype plugin (`src/lib/rehype-budoux.ts`) inserts `<wbr>` between BudouX-segmented phrases. Skips `pre`/`code`.
- **Phase 2 — titles & descriptions**: `<Budoux>` Astro component for static markup (article `<h1>`, `PostCard`, `RelatedArticles`, page `<h1>`). React island `InfinitePostList` calls the parser inline so SSR'd post titles get the same treatment.
- **Phase 3 — remaining surfaces**: index hero text, Footer description, 404 / NotFound, Portfolio (Profile summary / WorkExperience description / Projects description / CollapsibleRoles role description), AffiliateCard title+description, CVExportButton.

Global CSS lives in `src/styles/budoux.css` and is loaded by `Layout.astro` so `[data-budoux] { word-break: keep-all; overflow-wrap: anywhere; }` applies everywhere — not just inside `prose`.

## Why

Chromium ships `word-break: auto-phrase` natively but Safari and Firefox don't, so without help Japanese wraps mid-phrase ("独自性" → "独 / 自性"). BudouX runs at build time, ~20KB dep, no runtime cost on static pages. Inspired by https://h6i.org/blog/posts/astro-budoux-linebreak.html.

## Out of scope (intentionally skipped)

`LinkCard` / `ArticleTOC` (truncate, single-line), `ShareButtons` / Header nav (English labels), Tag / Skill / Cert / Edu badges (single-word), `/en/portfolio` (English).

## Test plan

- [x] `pnpm check` — 0 errors / 0 warnings
- [x] `pnpm build` — 189 pages built (broken draft `review-benq-screenbar-halo.mdx` temporarily moved aside; unrelated MDX parse error)
- [x] DOM verified: 1602 `<wbr>` and 175 `[data-budoux]` on harness landscape post; 199 `<wbr>` on portfolio
- [x] Computed style on `<h1[data-budoux]>` returns `word-break: keep-all` + `overflow-wrap: anywhere`
- [x] Before/after screenshot at 420px: title wrap improves from "11 / の記事" + "独 / 自性" to "11の記事" + "独自性" preserved
- [ ] Cross-browser smoke (Safari / Firefox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
