### PR TITLE
feat(design): layered JP/EN typography with jp-ui-contracts principles

### DIFF
--- a/docs/adr/0001-prose-typography-layered-design.md
+++ b/docs/adr/0001-prose-typography-layered-design.md
@@ -1,0 +1,68 @@
+# ADR-0001: Adopt Layered JP/EN Typography Design (jp-ui-contracts inspired)
+
+## Status
+
+Proposed
+
+## Context
+
+funailog は日本語 + 英語混在の技術ブログで、直近の #112 で `rehype-budoux` プラグインを導入し、全テキストノードに `<wbr>` を挿入して句節単位の改行を実現した。導入後、以下の副作用が観測された：
+
+- リンクテキスト内部にも `<wbr>` が入るため、リンク文字列が句節境界で途中改行される
+- `prose.css` のリンクは `decoration-transparent`（hover 時のみ下線）で、色弱/ダークモード/改行時に認識が難しい
+- `word-break: keep-all` + greedy 改行の副作用で、右端に大きな空白（穴ボコ）が残る
+- 和欧混植（「TanStack Queryの設定」等）で自動スペーシングが効かず、ぎこちない
+
+参考として hirokaji/jp-ui-contracts（日本語 UI 設計契約キット）を調査した結果、本文/見出し/リンク/和欧混植を **別レイヤとして設計** することが実効的と判明。
+
+## Decision
+
+jp-ui-contracts のレシピ群を参考に、以下のレイヤ分離を採用する：
+
+1. **本文レイヤ** (`p`, `li`): `text-wrap: pretty` による全体最適化された改行
+2. **見出しレイヤ** (`h1`-`h4`): `word-break: auto-phrase` + `text-wrap: balance`
+3. **リンクレイヤ** (`a`): rehype-budoux から除外 + 常時下線表示 + `underline-offset-3` で全箇所統一
+4. **和欧混植レイヤ** (`:lang(ja)`): `text-autospace: normal` で自動スペーシング
+
+BudouX は Safari/Firefox 向けの句節改行フォールバックとして維持する（撤去はしない）。
+
+同じ改修機会で以下の周辺修正も実施する（ホリスティックレビューで顕在化した問題）：
+
+- **Focus ring の大域化**: `:focus-visible` を `prose.css`（記事ルートのみ）から `budoux.css`（Layout でグローバル import）へ移動。WCAG 2.4.7 退行を解消。
+- **`underline-offset` 統一**: プロジェクト全体で `-3` に揃える（現状は `-2` / `-3` / `-4` の 3 種が混在）。
+
+代替案として検討したもの：
+
+- **案A: 下線だけ直す最小変更**: 穴ボコ問題とリンク途中改行が未解決
+- **案B: BudouX 撤去して `auto-phrase` 一本化**: Safari で退行
+- **採用案（案1改）**: BudouX を保持しつつレイヤ分離で弱点補正
+
+## Consequences
+
+### Positive
+
+- リンクが途中で切れなくなる（可読性と認識性の両方が向上）
+- 下線の常時表示で WCAG 1.4.1（色のみに頼らない）の達成に寄与
+- Focus ring が全ページで効き、WCAG 2.4.7 Focus Visible 退行を解消
+- `underline-offset` 統一でリンクの視覚言語が一貫
+- Chrome/Edge ユーザーは `text-wrap: pretty` と `text-autospace` でさらにリッチな体験
+- jp-ui-contracts の契約思想を取り込むことで、今後の UI 拡張時の判断軸が揃う
+- Safari ユーザーも BudouX `<wbr>` の恩恵を引き続き受けられる（退行なし）
+
+### Negative
+
+- CSS の複雑度が増す（4 レイヤの規則が並立）
+- `text-autospace` は Chrome 137+（2025 年夏）のみで、現時点では限定的な機能
+- `color-mix()` を使う箇所で古いブラウザのフォールバック設計が必要
+- BudouX と `auto-phrase` の二重適用で、稀に見出しの改行が不自然になる可能性（観測時に個別対処）
+
+### Neutral
+
+- `rehype-budoux.ts` の除外タグが `['pre', 'code']` → `['pre', 'code', 'a']` に拡張される
+- 既存の色トークン（`--link` 等）は変更しない
+
+## References
+
+- hirokaji/jp-ui-contracts: https://github.com/hirokaji/jp-ui-contracts
+- Spec: `docs/superpowers/specs/2026-04-22-prose-typography-jp-ui-design.md`
+- 関連 PR: #112 (feat(layout): apply BudouX phrase-aware line wrapping site-wide)

--- a/package.json
+++ b/package.json
@@ -131,6 +131,8 @@
     "prettier-plugin-tailwindcss": "^0.7.2",
     "reading-time": "^1.5.0",
     "rehype-autolink-headings": "^7.1.0",
+    "rehype-parse": "9.0.1",
+    "rehype-stringify": "10.0.1",
     "satori": "^0.18.3",
     "sharp": "^0.34.5",
     "tsx": "^4.21.0",

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "typescript-eslint": "^8.50.1",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
+    "unist-util-visit-parents": "6.0.2",
     "vitest": "4.1.2",
     "yaml": "^2.8.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,12 @@ importers:
       rehype-autolink-headings:
         specifier: ^7.1.0
         version: 7.1.0
+      rehype-parse:
+        specifier: 9.0.1
+        version: 9.0.1
+      rehype-stringify:
+        specifier: 10.0.1
+        version: 10.0.1
       satori:
         specifier: ^0.18.3
         version: 0.18.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
+      unist-util-visit-parents:
+        specifier: 6.0.2
+        version: 6.0.2
       vitest:
         specifier: 4.1.2
         version: 4.1.2(@types/node@24.10.4)(vite@7.3.2(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -5569,9 +5572,6 @@ packages:
 
   unist-util-visit-children@3.0.0:
     resolution: {integrity: sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==}
-
-  unist-util-visit-parents@6.0.1:
-    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
 
   unist-util-visit-parents@6.0.2:
     resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
@@ -12621,11 +12621,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  unist-util-visit-parents@6.0.1:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.0
-
   unist-util-visit-parents@6.0.2:
     dependencies:
       '@types/unist': 3.0.3
@@ -12635,7 +12630,7 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
-      unist-util-visit-parents: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   unist-util-visit@5.1.0:
     dependencies:

--- a/src/components/Link.astro
+++ b/src/components/Link.astro
@@ -30,30 +30,10 @@ const linkClass = cn(linkStyles.base, linkStyles.inline);
       target="_blank"
       rel="noopener noreferrer"
       href={props.href}
-      class:list={[linkClass, 'external-link']}
+      class={linkClass}
       aria-label={`${props.href} (${t('a11y.externalLink')})`}
     >
       <slot />
     </a>
   )
 }
-
-<style>
-  .external-link::after {
-    content: '';
-    display: inline-block;
-    width: 0.7em;
-    height: 0.7em;
-    margin-left: 0.1em;
-    vertical-align: baseline;
-    opacity: 0.4;
-    transition: opacity 150ms;
-    background-color: currentColor;
-    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M7 17L17 7'/%3E%3Cpath d='M7 7h10v10'/%3E%3C/svg%3E");
-    mask-size: contain;
-    mask-repeat: no-repeat;
-  }
-  .external-link:hover::after {
-    opacity: 0.8;
-  }
-</style>

--- a/src/components/Link.astro
+++ b/src/components/Link.astro
@@ -30,10 +30,30 @@ const linkClass = cn(linkStyles.base, linkStyles.inline);
       target="_blank"
       rel="noopener noreferrer"
       href={props.href}
-      class={linkClass}
+      class:list={[linkClass, 'external-link']}
       aria-label={`${props.href} (${t('a11y.externalLink')})`}
     >
       <slot />
     </a>
   )
 }
+
+<style>
+  .external-link::after {
+    content: '';
+    display: inline-block;
+    width: 0.7em;
+    height: 0.7em;
+    margin-left: 0.1em;
+    vertical-align: baseline;
+    opacity: 0.4;
+    transition: opacity 150ms;
+    background-color: currentColor;
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M7 17L17 7'/%3E%3Cpath d='M7 7h10v10'/%3E%3C/svg%3E");
+    mask-size: contain;
+    mask-repeat: no-repeat;
+  }
+  .external-link:hover::after {
+    opacity: 0.8;
+  }
+</style>

--- a/src/components/LinkCard.astro
+++ b/src/components/LinkCard.astro
@@ -20,7 +20,7 @@ const faviconUrl = `https://www.google.com/s2/favicons?domain=${hostname}&sz=32`
       target="_blank"
       rel="noopener noreferrer"
       href={props.href}
-      class="text-link hover:text-link-hover inline-flex items-center gap-1 underline-offset-2 hover:underline"
+      class="text-link hover:text-link-hover inline-flex items-center gap-1 underline-offset-3 hover:underline"
     >
       <slot />
       <svg

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
         secondary:
           'hover:bg-secondary/80 bg-secondary text-secondary-foreground',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-link underline-offset-4 hover:text-link-hover hover:underline',
+        link: 'text-link underline-offset-3 hover:text-link-hover hover:underline',
       },
       size: {
         default: 'h-9 px-4 py-2',

--- a/src/lib/rehype-budoux.test.ts
+++ b/src/lib/rehype-budoux.test.ts
@@ -41,4 +41,15 @@ describe('rehypeBudoux', () => {
     expect(anchorInner).not.toContain('<wbr>');
     expect(anchorInner).toBe('公式ドキュメントを読みます');
   });
+
+  it('does not insert <wbr> inside <a> with nested inline elements', async () => {
+    const output = await process(
+      '<p>まずは<a href="https://example.com"><strong>公式ドキュメントを読みます</strong></a>の続き。</p>',
+    );
+    // Everything between <a ...> and </a> must be <wbr>-free
+    const anchorMatch = output.match(/<a[^>]*>([\s\S]*?)<\/a>/);
+    expect(anchorMatch).not.toBeNull();
+    const anchorInner = anchorMatch![1];
+    expect(anchorInner).not.toContain('<wbr>');
+  });
 });

--- a/src/lib/rehype-budoux.test.ts
+++ b/src/lib/rehype-budoux.test.ts
@@ -1,0 +1,44 @@
+import rehypeParse from 'rehype-parse';
+import rehypeStringify from 'rehype-stringify';
+import { unified } from 'unified';
+import { describe, it, expect } from 'vitest';
+
+import rehypeBudoux from './rehype-budoux';
+
+async function process(html: string): Promise<string> {
+  const file = await unified()
+    .use(rehypeParse, { fragment: true })
+    .use(rehypeBudoux)
+    .use(rehypeStringify)
+    .process(html);
+  return String(file);
+}
+
+describe('rehypeBudoux', () => {
+  it('inserts <wbr> into plain Japanese paragraphs', async () => {
+    const output = await process('<p>今日はいい天気ですね。</p>');
+    expect(output).toContain('<wbr>');
+    expect(output).toContain('data-budoux');
+  });
+
+  it('does not insert <wbr> inside <pre> or <code>', async () => {
+    const output = await process(
+      '<pre>今日はいい天気ですね。</pre><code>今日はいい天気ですね。</code>',
+    );
+    expect(output).not.toContain('<wbr>');
+  });
+
+  it('does not insert <wbr> inside <a> (keeps links atomic)', async () => {
+    const output = await process(
+      '<p>まずは<a href="https://example.com">公式ドキュメントを読みます</a>の続き。</p>',
+    );
+    // The surrounding <p> should still be segmented
+    expect(output).toContain('data-budoux');
+    // But the <a> content must not contain <wbr>
+    const anchorMatch = output.match(/<a[^>]*>([^<]*(?:<(?!\/a>)[^<]*)*)<\/a>/);
+    expect(anchorMatch).not.toBeNull();
+    const anchorInner = anchorMatch![1];
+    expect(anchorInner).not.toContain('<wbr>');
+    expect(anchorInner).toBe('公式ドキュメントを読みます');
+  });
+});

--- a/src/lib/rehype-budoux.ts
+++ b/src/lib/rehype-budoux.ts
@@ -10,7 +10,7 @@ interface Options {
   excludeTagNames?: string[];
 }
 
-const defaultExcludeTagNames = ['pre', 'code'];
+const defaultExcludeTagNames = ['pre', 'code', 'a'];
 
 let parser: HTMLProcessingParser | null = null;
 

--- a/src/lib/rehype-budoux.ts
+++ b/src/lib/rehype-budoux.ts
@@ -1,9 +1,9 @@
 import { loadDefaultJapaneseParser } from 'budoux';
 import { h } from 'hastscript';
-import { visit } from 'unist-util-visit';
+import { visitParents } from 'unist-util-visit-parents';
 
 import type { HTMLProcessingParser } from 'budoux';
-import type { Root } from 'hast';
+import type { Element, Root } from 'hast';
 import type { Plugin } from 'unified';
 
 interface Options {
@@ -18,12 +18,22 @@ const rehypeBudoux: Plugin<[Options?], Root> = ({
   excludeTagNames = defaultExcludeTagNames,
 }: Options = {}) => {
   return (tree) => {
-    visit(tree, 'text', (node, index, parent) => {
+    visitParents(tree, 'text', (node, ancestors) => {
+      const parent = ancestors[ancestors.length - 1];
+      const index = parent
+        ? (parent as Element).children?.indexOf(node)
+        : undefined;
       if (
         index === undefined ||
+        index === -1 ||
         !parent ||
         parent.type !== 'element' ||
-        excludeTagNames.includes(parent.tagName) ||
+        excludeTagNames.includes((parent as Element).tagName) ||
+        ancestors.some(
+          (a): a is Element =>
+            a.type === 'element' &&
+            excludeTagNames.includes((a as Element).tagName),
+        ) ||
         node.value.trim().length === 0
       ) {
         return;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,7 +9,7 @@ export function cn(...inputs: ClassValue[]) {
  * Shared link style classes for consistent link appearance
  */
 export const linkStyles = {
-  base: 'text-link visited:text-link-visited hover:text-link-hover underline decoration-transparent hover:decoration-current active:text-link-active transition-[color,text-decoration-color] duration-150',
+  base: 'text-link visited:text-link-visited hover:text-link-hover underline underline-offset-3 decoration-link/40 hover:decoration-link-hover active:text-link-active transition-[color,text-decoration-color] duration-150',
   inline: 'inline-flex items-center gap-1',
 } as const;
 

--- a/src/styles/budoux.css
+++ b/src/styles/budoux.css
@@ -31,7 +31,9 @@ html:lang(ja) {
   overflow-wrap: anywhere;
 }
 
-/* External links get a dashed underline to distinguish from internal links */
+/* External links get a dotted underline to distinguish from internal links */
 a[target='_blank'] {
-  text-decoration-style: dashed;
+  text-decoration-style: dotted;
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 3px;
 }

--- a/src/styles/budoux.css
+++ b/src/styles/budoux.css
@@ -17,14 +17,6 @@ html:lang(ja) {
   word-break: auto-phrase;
 }
 
-/* Links, product names, and inline emphasis stay atomic with fallback breaking */
-:lang(ja) a,
-:lang(ja) em,
-:lang(ja) strong {
-  word-break: normal;
-  overflow-wrap: anywhere;
-}
-
 /* BudouX: keep Japanese phrases together at <wbr> boundaries */
 [data-budoux] {
   word-break: keep-all;

--- a/src/styles/budoux.css
+++ b/src/styles/budoux.css
@@ -31,11 +31,9 @@ html:lang(ja) {
   overflow-wrap: anywhere;
 }
 
-/* External links: dotted underline at full opacity to clearly
-   distinguish from internal links (which stay subtle at 40%). */
+/* External links get a dotted underline to distinguish from internal links */
 a[target='_blank'] {
   text-decoration-style: dotted;
-  text-decoration-color: currentColor;
   text-decoration-thickness: 1.5px;
   text-underline-offset: 3px;
 }

--- a/src/styles/budoux.css
+++ b/src/styles/budoux.css
@@ -17,8 +17,11 @@ html:lang(ja) {
   word-break: auto-phrase;
 }
 
-/* BudouX: keep Japanese phrases together at <wbr> boundaries */
+/* BudouX-segmented text: prefer browser-native phrase wrapping
+   on Chrome 119+, with <wbr> as a break hint. Falls back to
+   word-break: normal in Safari — pretty line-wrap + wbr hints
+   still produce reasonable results. */
 [data-budoux] {
-  word-break: keep-all;
+  word-break: auto-phrase;
   overflow-wrap: anywhere;
 }

--- a/src/styles/budoux.css
+++ b/src/styles/budoux.css
@@ -30,3 +30,8 @@ html:lang(ja) {
   word-break: keep-all;
   overflow-wrap: anywhere;
 }
+
+/* External links get a dashed underline to distinguish from internal links */
+a[target='_blank'] {
+  text-decoration-style: dashed;
+}

--- a/src/styles/budoux.css
+++ b/src/styles/budoux.css
@@ -31,9 +31,11 @@ html:lang(ja) {
   overflow-wrap: anywhere;
 }
 
-/* External links get a dotted underline to distinguish from internal links */
+/* External links: dotted underline at full opacity to clearly
+   distinguish from internal links (which stay subtle at 40%). */
 a[target='_blank'] {
   text-decoration-style: dotted;
+  text-decoration-color: currentColor;
   text-decoration-thickness: 1.5px;
   text-underline-offset: 3px;
 }

--- a/src/styles/budoux.css
+++ b/src/styles/budoux.css
@@ -1,3 +1,31 @@
+@reference "./tokens.css";
+
+/* WCAG 2.4.7 Focus Visible — global because Layout loads this file */
+:focus-visible {
+  @apply ring-ring ring-2 ring-offset-2 outline-none;
+  ring-offset-color: var(--color-background);
+}
+
+/* Japanese mixed-script foundation (jp-ui-contracts inspired) */
+html:lang(ja) {
+  text-autospace: normal;
+}
+
+:lang(ja) h1,
+:lang(ja) h2,
+:lang(ja) h3,
+:lang(ja) h4 {
+  word-break: auto-phrase;
+}
+
+/* Links, product names, and inline emphasis stay atomic with fallback breaking */
+:lang(ja) a,
+:lang(ja) em,
+:lang(ja) strong {
+  word-break: normal;
+  overflow-wrap: anywhere;
+}
+
 /* BudouX: keep Japanese phrases together at <wbr> boundaries */
 [data-budoux] {
   word-break: keep-all;

--- a/src/styles/budoux.css
+++ b/src/styles/budoux.css
@@ -2,7 +2,7 @@
 
 /* WCAG 2.4.7 Focus Visible — global because Layout loads this file */
 :focus-visible {
-  @apply ring-ring ring-2 ring-offset-2 ring-offset-background outline-none;
+  @apply ring-ring ring-offset-background ring-2 ring-offset-2 outline-none;
 }
 
 /* Japanese mixed-script foundation (jp-ui-contracts inspired) */

--- a/src/styles/budoux.css
+++ b/src/styles/budoux.css
@@ -30,9 +30,3 @@ html:lang(ja) {
   word-break: keep-all;
   overflow-wrap: anywhere;
 }
-
-/* External links get a wavy underline to distinguish from internal links */
-a[target='_blank'] {
-  text-decoration-style: wavy;
-  text-underline-offset: 3px;
-}

--- a/src/styles/budoux.css
+++ b/src/styles/budoux.css
@@ -31,9 +31,8 @@ html:lang(ja) {
   overflow-wrap: anywhere;
 }
 
-/* External links get a dotted underline to distinguish from internal links */
+/* External links get a wavy underline to distinguish from internal links */
 a[target='_blank'] {
-  text-decoration-style: dotted;
-  text-decoration-thickness: 1.5px;
+  text-decoration-style: wavy;
   text-underline-offset: 3px;
 }

--- a/src/styles/budoux.css
+++ b/src/styles/budoux.css
@@ -2,8 +2,7 @@
 
 /* WCAG 2.4.7 Focus Visible — global because Layout loads this file */
 :focus-visible {
-  @apply ring-ring ring-2 ring-offset-2 outline-none;
-  ring-offset-color: var(--color-background);
+  @apply ring-ring ring-2 ring-offset-2 ring-offset-background outline-none;
 }
 
 /* Japanese mixed-script foundation (jp-ui-contracts inspired) */

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -1,11 +1,5 @@
 @reference "./tokens.css";
 
-/* WCAG 2.1 focus indicators */
-:focus-visible {
-  @apply ring-ring ring-2 ring-offset-2 outline-none;
-  ring-offset-color: var(--color-background);
-}
-
 body {
   article {
     /* prose with responsive font size */
@@ -17,6 +11,7 @@ body {
 
     & p {
       @apply my-5;
+      text-wrap: pretty;
     }
 
     & ul {
@@ -28,6 +23,7 @@ body {
     & li {
       @apply list-outside;
       @apply my-1.5;
+      text-wrap: pretty;
     }
 
     /* Heading hierarchy */
@@ -37,7 +33,7 @@ body {
     & h4,
     & h5,
     & h6 {
-      text-wrap: wrap;
+      text-wrap: balance;
       word-break: normal;
     }
     & h1 {
@@ -93,10 +89,15 @@ body {
       }
     }
     & a {
-      @apply text-link underline decoration-transparent underline-offset-3 transition-[color,text-decoration-color];
+      @apply text-link underline underline-offset-3 transition-[color,text-decoration-color];
+      /* Fallback for browsers without color-mix() (Safari < 16.2) */
+      text-decoration-color: var(--color-link);
+      /* Modern browsers: 40% opacity via color-mix */
+      text-decoration-color: color-mix(in oklab, currentColor 40%, transparent);
       transition-duration: var(--duration-fast);
       &:hover {
-        @apply text-link-hover decoration-current;
+        @apply text-link-hover;
+        text-decoration-color: currentColor;
       }
     }
     & code {

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -6,8 +6,13 @@ body {
     @apply prose dark:prose-invert max-w-none flex-grow break-words;
     @apply text-sm md:text-base;
 
-    /* Japanese-optimized line height */
-    line-height: 1.8;
+    /* Japanese-optimized line height — slightly tighter on mobile
+       so a higher character count fits in view without feeling cramped */
+    line-height: 1.7;
+
+    @media (min-width: 48rem) {
+      line-height: 1.8;
+    }
 
     /* Let JA punctuation hang at line end for cleaner right edges
        (Safari only) and opt into browser's default JA spacing trim */

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -9,6 +9,11 @@ body {
     /* Japanese-optimized line height */
     line-height: 1.8;
 
+    /* Let JA punctuation hang at line end for cleaner right edges
+       (Safari only) and opt into browser's default JA spacing trim */
+    hanging-punctuation: allow-end;
+    text-spacing-trim: normal;
+
     & p {
       @apply my-5;
       text-wrap: pretty;


### PR DESCRIPTION
## Summary
- **BudouX**: rehype plugin excludes `<a>` from `<wbr>` insertion (with ancestor walk), so inline links no longer break mid-phrase in Japanese prose
- **Layered JP/EN typography** inspired by [hirokaji/jp-ui-contracts](https://github.com/hirokaji/jp-ui-contracts): `text-wrap: pretty/balance`, `word-break: auto-phrase`, `text-autospace: normal`, `hanging-punctuation`, `text-spacing-trim`
- **Always-on link underline** at 40% opacity via `color-mix()` with single-color fallback (Safari < 16.2)
- **`:focus-visible` moved** from `prose.css` (article-only) to `budoux.css` (global) — fixes WCAG 2.4.7 regression on home/portfolio/404; along the way replaces the silently-ignored `ring-offset-color` with `ring-offset-background`
- **`underline-offset` unified** at `-3` across `prose.css` / `LinkCard.astro` / `Button` link variant
- **Mobile line-height** tightened to 1.7 (desktop stays 1.8) for higher information density on small screens

See [`docs/adr/0001-prose-typography-layered-design.md`](docs/adr/0001-prose-typography-layered-design.md) for rationale.

## Logical units (suggested squash-merge grouping)
The branch has exploration commits on external-link styling that cancel each other out. Recommend **Squash and merge** via GitHub UI. The net diff groups into:

1. **fix(budoux)**: exclude `<a>` from `<wbr>` with ancestor walk + vitest coverage
2. **feat(styles)**: layered JP/EN typography + always-on link underline + mobile line-height
3. **fix(styles)**: globalize `:focus-visible` + correct `ring-offset-color` bug
4. **refactor(links)**: unify `underline-offset-3` across components
5. **docs(adr)**: record layered typography decision

## Test plan
- [x] `pnpm test` — 102/102 passing (4 new rehype-budoux tests)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — 189 pages built
- [ ] Verify in browser: link mid-phrase breaks gone (`/blog/2026/harness-engineering-landscape`)
- [ ] Verify in browser: `<strong>` no longer breaks mid-katakana (`/blog/2026/hono-problem-details-rfc9457` — "クランプ" no longer splits)
- [ ] Verify in browser: always-on 40% link underline in both light & dark mode
- [ ] Verify in browser: focus ring visible on Tab across home / portfolio / 404 / demos
- [ ] Verify in browser: mobile line-height feels right (< 768px)
- [ ] Cross-browser: Safari falls back cleanly (BudouX `<wbr>` hints, single-color underline, hanging-punctuation active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)