### PR TITLE
feat(seo): add llms.txt endpoint with footer and robots.txt hints

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
+# No AI training crawl (Google-Extended covers Gemini/Vertex training).
+# llms.txt below is for LLMs citing/referencing pages at query time, not training.
 User-Agent: Google-Extended
 Disallow: /
 
@@ -6,3 +8,4 @@ Allow: /
 
 Host: https://www.funailog.com
 Sitemap: https://www.funailog.com/sitemap-index.xml
+# LLM guide: https://www.funailog.com/llms.txt

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -56,6 +56,11 @@ const startYear = 2023;
             >RSS</a
           >
         </li>
+        <li>
+          <a href="/llms.txt" class="hover:text-foreground transition-colors"
+            >llms.txt</a
+          >
+        </li>
       </ul>
     </div>
 

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,87 @@
+import type { APIContext } from 'astro';
+import { getCollection, getEntry, type CollectionEntry } from 'astro:content';
+
+import { CATEGORIES, type Category } from '@/config/site';
+
+const CATEGORY_LABELS: Record<Category, string> = {
+  programming: 'Programming',
+  design: 'Design',
+  gadgets: 'Gadgets',
+  travel: 'Travel',
+  lifestyle: 'Lifestyle',
+  vehicles: 'Vehicles',
+  other: 'Other',
+};
+
+const formatDate = (date: Date): string => date.toISOString().slice(0, 10);
+
+const escapeDescription = (text: string): string =>
+  text.replace(/\s+/g, ' ').trim();
+
+const renderPostLine = (post: CollectionEntry<'blog'>, site: URL): string => {
+  const url = new URL(`/${post.collection}/${post.id}/`, site).toString();
+  const description = escapeDescription(post.data.description);
+  const date = formatDate(post.data.published);
+  return `- [${post.data.title}](${url}): ${description} (${date})`;
+};
+
+export async function GET(context: APIContext): Promise<Response> {
+  const meta = await getEntry('site', 'meta');
+  if (!meta) {
+    throw new Error('Site meta configuration not found');
+  }
+  const site = context.site;
+  if (!site) {
+    throw new Error('Astro `site` is not configured');
+  }
+
+  const posts = (await getCollection('blog'))
+    .filter((post) => post.data.isPublished)
+    .sort((a, b) => b.data.published.getTime() - a.data.published.getTime());
+
+  const postsByCategory = new Map<Category, CollectionEntry<'blog'>[]>();
+  for (const post of posts) {
+    const list = postsByCategory.get(post.data.category) ?? [];
+    list.push(post);
+    postsByCategory.set(post.data.category, list);
+  }
+
+  const lines: string[] = [];
+  lines.push(`# ${meta.data.rss.title}`);
+  lines.push('');
+  lines.push(`> ${meta.data.rss.description}`);
+  lines.push('');
+  lines.push(
+    'ガジェット・仕事道具・乗り物、そして技術について綴る個人メディアです。記事本文は日本語で書かれています。',
+  );
+  lines.push('');
+  lines.push(`- Author: ${meta.data.author.name}`);
+  lines.push(`- Site: ${site.toString()}`);
+  lines.push(`- RSS: ${new URL('/rss.xml', site).toString()}`);
+  lines.push(`- Sitemap: ${new URL('/sitemap-index.xml', site).toString()}`);
+  lines.push('');
+
+  for (const category of CATEGORIES) {
+    const entries = postsByCategory.get(category);
+    if (!entries || entries.length === 0) continue;
+    lines.push(`## ${CATEGORY_LABELS[category]}`);
+    lines.push('');
+    for (const post of entries) {
+      lines.push(renderPostLine(post, site));
+    }
+    lines.push('');
+  }
+
+  const body =
+    lines
+      .join('\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trimEnd() + '\n';
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Add `/llms.txt` (`src/pages/llms.txt.ts`) — [llmstxt.org](https://llmstxt.org)-format index of published blog posts grouped by category, built from the `blog` collection and `site/meta`
- Link `llms.txt` from the footer `nav` column, next to `RSS`
- Annotate `public/robots.txt` with a `# LLM guide: ...` pointer plus a comment clarifying that `Google-Extended: Disallow: /` (training block) and `llms.txt` (reference-time guide) are intentionally separate concerns

## Test plan
- [x] `pnpm astro check` passes (0 errors / 0 warnings)
- [x] `pnpm astro build` succeeds; `dist/llms.txt` generated (~15KB, 61 lines) with expected Markdown structure (H1 title, blockquote description, H2 per category, `- [title](url): description (YYYY-MM-DD)` entries)
- [x] `dist/robots.txt` contains the `# LLM guide: https://www.funailog.com/llms.txt` line
- [x] `dist/index.html` footer `nav` renders the `llms.txt` link immediately after `RSS`
- [x] `dist/sitemap-0.xml` does **not** include `/llms.txt` or `/rss.xml` (astro-sitemap's default non-HTML filter handles this; no sitemap config change required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)