### PR TITLE
feat(design): soften JA phrase-wrap raggedness on short-text surfaces

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -21,10 +21,10 @@ const startYear = 2023;
     {/* Column 1: Site identity */}
     <div class="space-y-2">
       <p class="text-foreground font-medium">funailog.com</p>
-      <p class="hidden leading-relaxed sm:block" data-budoux>
+      <p class="hidden leading-relaxed text-balance sm:block" data-budoux>
         <Budoux text={t('footer.description')} />
       </p>
-      <p class="leading-relaxed sm:hidden" data-budoux>
+      <p class="leading-relaxed text-balance sm:hidden" data-budoux>
         <Budoux text={t('footer.descriptionShort')} />
       </p>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -54,7 +54,10 @@ const otherPosts = recentPosts.slice(1);
       </div>
       <div class="space-y-3">
         <h1 class="font-heading text-2xl md:text-3xl">{t('main.title')}</h1>
-        <p class="text-muted-foreground text-lg font-medium" data-budoux>
+        <p
+          class="text-muted-foreground text-lg font-medium text-balance"
+          data-budoux
+        >
           <Budoux text={t('index.tagline')} />
         </p>
         <p

--- a/src/styles/budoux.css
+++ b/src/styles/budoux.css
@@ -20,8 +20,13 @@ html:lang(ja) {
 /* BudouX-segmented text: prefer browser-native phrase wrapping
    on Chrome 119+, with <wbr> as a break hint. Falls back to
    word-break: normal in Safari — pretty line-wrap + wbr hints
-   still produce reasonable results. */
+   still produce reasonable results.
+
+   text-wrap: pretty reduces orphans and short last lines. Heading-
+   level balance lives in prose.css (article scope) and per-element
+   text-balance utilities (hero tagline, footer descriptions). */
 [data-budoux] {
   word-break: auto-phrase;
   overflow-wrap: anywhere;
+  text-wrap: pretty;
 }


### PR DESCRIPTION
## Summary
- Apply `text-wrap: pretty` to the `[data-budoux]` base rule — the main effect is avoiding orphan words and very short last lines across BudouX-annotated copy
- Add `text-balance` Tailwind utility to the homepage hero tagline and both footer descriptions so those short blocks distribute line lengths evenly
- Scope is narrow by design: no global heading selector, so `prose.css` keeps owning article-scope balance and the blog `<h1>`'s intentional `[text-wrap:wrap]` opt-out (commit 9d024b2) is preserved

## Background
Diagnosed on mobile viewports where the layout visually "doesn't use 100% of the screen width." Real cause: phrase-aware wrapping (`word-break: auto-phrase` + `<wbr>` hints emitted by BudouX) leaves ragged right edges — intentional Japanese typography behaviour, but visually softer when short copy is balanced.

## Reviewer-sourced guardrails this PR respects
- Does **not** re-enable balance on the blog article `<h1>` (`src/pages/blog/[...slug].astro:97`), which has an explicit `[text-wrap:wrap]` added in #64 to avoid Chromium's 6-line balance cap on long JA titles
- Does **not** duplicate the `article h1-h6 { text-wrap: balance }` rule already present in `src/styles/prose.css:45`
- `PostCard` / `RelatedArticles` / portfolio headings keep their default wrap behaviour (no new global heading rule)

## Known follow-up
`text-wrap: pretty` is an orphan-suppression heuristic, not a line-filler. If visible raggedness on mobile is still a concern after this change, the next lever is BudouX `<wbr>` density, not more CSS. Verify in a real mobile viewport before going further.

## Test plan
- [x] `pnpm astro check` passes (0 errors / 0 warnings)
- [ ] Manual browser verification on 375px viewport: homepage hero tagline, footer descriptions
- [ ] Confirm article title rendering is unchanged (intentional `[text-wrap:wrap]` still effective)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
