### PR TITLE
feat: article UX improvements — headings, share, related, TOC, tags

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -10,6 +10,7 @@ import expressiveCode from 'astro-expressive-code';
 import { h } from 'hastscript';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeMermaid from 'rehype-mermaid';
+import rehypeSlug from 'rehype-slug';
 
 import rehypeBudoux from './src/lib/rehype-budoux';
 import rehypeUnwrapSvgP from './src/lib/rehype-unwrap-svg-p';
@@ -67,10 +68,11 @@ export default defineConfig({
           strategy: 'pre-mermaid',
         },
       ],
+      rehypeSlug,
       [
         rehypeAutolinkHeadings,
         {
-          behavior: 'append',
+          behavior: 'prepend',
           properties(node: Element) {
             return {
               'aria-labelledby': node.properties.id,

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "rehype-mermaid": "3.0.0",
+    "rehype-slug": "6.0.0",
     "schema-dts": "^1.1.5",
     "tailwind-merge": "^2.2.2",
     "tailwindcss": "4.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       rehype-mermaid:
         specifier: 3.0.0
         version: 3.0.0(playwright@1.60.0)
+      rehype-slug:
+        specifier: 6.0.0
+        version: 6.0.0
       schema-dts:
         specifier: ^1.1.5
         version: 1.1.5
@@ -5321,6 +5324,9 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-slug@6.0.0:
+    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
@@ -12708,6 +12714,14 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
+
+  rehype-slug@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      github-slugger: 2.0.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-string: 3.0.1
+      unist-util-visit: 5.1.0
 
   rehype-stringify@10.0.1:
     dependencies:

--- a/src/components/ShareButtons.astro
+++ b/src/components/ShareButtons.astro
@@ -31,44 +31,39 @@ const platforms = [
 const hatenaHref = `https://b.hatena.ne.jp/entry/${encodeURIComponent(url)}`;
 ---
 
-<div class="border-border mt-12 border-t pt-6">
-  <p class="font-code text-muted-foreground mb-3 text-center text-xs">
-    {t('share.label')}
-  </p>
-  <div class="flex items-center justify-center gap-3">
+<div class="mt-12 pt-6">
+  <div class="flex flex-wrap items-center justify-center gap-2">
     {
       platforms.map((p) => (
         <a
           href={p.href}
           target="_blank"
           rel="noopener noreferrer"
-          class="text-muted-foreground hover:text-foreground inline-flex size-8 items-center justify-center rounded-md transition-colors"
+          class="border-border hover:bg-accent hover:text-accent-foreground text-muted-foreground inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs transition-colors"
           aria-label={p.label}
-          title={p.name}
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            class="size-4"
+            class="size-3.5"
             viewBox="0 0 24 24"
             fill="currentColor"
           >
             <path d={p.pathD} />
           </svg>
+          {p.name}
         </a>
       ))
     }
-    {/* Hatena Bookmark */}
     <a
       href={hatenaHref}
       target="_blank"
       rel="noopener noreferrer"
-      class="text-muted-foreground hover:text-foreground inline-flex size-8 items-center justify-center rounded-md transition-colors"
+      class="border-border hover:bg-accent hover:text-accent-foreground text-muted-foreground inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs transition-colors"
       aria-label={t('share.hatena')}
-      title="Hatena"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        class="size-4"
+        class="size-3.5"
         viewBox="0 0 24 24"
         fill="currentColor"
       >
@@ -81,19 +76,18 @@ const hatenaHref = `https://b.hatena.ne.jp/entry/${encodeURIComponent(url)}`;
           font-family="system-ui">B!</text
         >
       </svg>
+      Hatena
     </a>
-    {/* Copy link */}
     <button
       id="copy-link-btn"
       type="button"
-      class="text-muted-foreground hover:text-foreground inline-flex size-8 items-center justify-center rounded-md transition-colors"
+      class="border-border hover:bg-accent hover:text-accent-foreground text-muted-foreground inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs transition-colors"
       aria-label={t('share.copyLink')}
-      title="Copy link"
       data-url={url}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        class="size-4"
+        class="size-3.5"
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"
@@ -106,6 +100,7 @@ const hatenaHref = `https://b.hatena.ne.jp/entry/${encodeURIComponent(url)}`;
         <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
         ></path>
       </svg>
+      Copy
     </button>
   </div>
 </div>

--- a/src/components/ShareButtons.astro
+++ b/src/components/ShareButtons.astro
@@ -100,7 +100,7 @@ const hatenaHref = `https://b.hatena.ne.jp/entry/${encodeURIComponent(url)}`;
         <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
         ></path>
       </svg>
-      Copy
+      <span>Copy</span>
     </button>
   </div>
 </div>
@@ -125,10 +125,16 @@ const hatenaHref = `https://b.hatena.ne.jp/entry/${encodeURIComponent(url)}`;
 
         try {
           await navigator.clipboard.writeText(url);
-          btn.classList.add('text-foreground');
-          setTimeout(() => {
-            btn.classList.remove('text-foreground');
-          }, 2000);
+          const label = btn.querySelector('span');
+          if (label) {
+            const orig = label.textContent;
+            label.textContent = 'Copied!';
+            btn.classList.add('text-foreground', 'bg-accent');
+            setTimeout(() => {
+              label.textContent = orig;
+              btn.classList.remove('text-foreground', 'bg-accent');
+            }, 2000);
+          }
         } catch {
           console.warn('Failed to copy to clipboard');
         }

--- a/src/components/article/ArticleHeader.astro
+++ b/src/components/article/ArticleHeader.astro
@@ -28,32 +28,72 @@ const hasDistinctUpdate = !!lastUpdatedOnly && lastUpdatedOnly !== dateOnly;
     >
       {category}
     </a>
-    <time datetime={published.toISOString()}>
-      {formatDateEn(published)}
-    </time>
+    <span class="flex items-center gap-1">
+      <svg
+        class="size-3.5"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        ><rect x="3" y="4" width="18" height="18" rx="2"></rect><path
+          d="M16 2v4"></path><path d="M8 2v4"></path><path d="M3 10h18"
+        ></path></svg
+      >
+      <time datetime={published.toISOString()}>
+        {formatDateEn(published)}
+      </time>
+    </span>
     {
       hasDistinctUpdate && lastUpdated && (
         <span class="flex items-center gap-1">
-          <span class="text-muted-foreground">updated</span>
+          <svg
+            class="size-3.5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <>
+              <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" />
+              <path d="M21 3v5h-5" />
+            </>
+          </svg>
           <time datetime={lastUpdated.toISOString()}>
             {formatDateEn(lastUpdated)}
           </time>
         </span>
       )
     }
-    <span class="text-muted-foreground">{minRead}</span>
+    <span class="text-muted-foreground flex items-center gap-1">
+      <svg
+        class="size-3.5"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        ><circle cx="12" cy="12" r="10"></circle><polyline
+          points="12 6 12 12 16 14"></polyline></svg
+      >
+      {minRead}
+    </span>
   </div>
 
   {/* Tags */}
   {
     tags.length > 0 && (
-      <div class="flex flex-wrap gap-x-2 gap-y-1">
+      <div class="flex flex-wrap gap-1.5">
         {tags.map((tag) => (
           <a
             href={`/${collection}/tags/${tag}`}
-            class="hover:text-foreground transition-colors"
+            class="border-border hover:bg-accent hover:text-accent-foreground rounded-md border px-2 py-0.5 text-xs transition-colors"
           >
-            #{tag}
+            {tag}
           </a>
         ))}
       </div>

--- a/src/components/article/ArticleTOC.astro
+++ b/src/components/article/ArticleTOC.astro
@@ -16,7 +16,7 @@ const t = useTranslations(defaultLang);
 
 {
   mode === 'mobile' ? (
-    <details class="toc-root border-border mb-6 rounded-md border lg:hidden">
+    <details class="toc-root border-border mb-6 rounded-md border xl:hidden">
       <summary class="font-code text-muted-foreground cursor-pointer px-4 py-2.5 text-xs select-none">
         {t('toc.title')}
       </summary>

--- a/src/components/article/ArticleTOC.astro
+++ b/src/components/article/ArticleTOC.astro
@@ -16,11 +16,11 @@ const t = useTranslations(defaultLang);
 
 {
   mode === 'mobile' ? (
-    <details class="toc-root border-border mb-6 rounded-md border">
-      <summary class="font-code text-muted-foreground cursor-pointer px-4 py-2.5 text-xs select-none">
+    <details class="toc-root bg-surface-sunken mb-8 rounded-lg" open>
+      <summary class="font-heading text-foreground cursor-pointer px-4 py-3 text-sm font-semibold select-none">
         {t('toc.title')}
       </summary>
-      <ul class="toc-list text-muted-foreground space-y-0.5 px-4 pb-3 text-xs" />
+      <ul class="toc-list text-muted-foreground space-y-1 px-4 pb-4 text-xs" />
     </details>
   ) : (
     <nav class="toc-root" aria-label={t('toc.ariaLabel')}>

--- a/src/components/article/ArticleTOC.astro
+++ b/src/components/article/ArticleTOC.astro
@@ -61,7 +61,11 @@ const t = useTranslations(defaultLang);
         const li = document.createElement('li');
         const a = document.createElement('a');
         a.href = `#${id}`;
-        a.textContent = h.textContent?.replace(/#$/, '').trim() ?? '';
+        const rawText = Array.from(h.childNodes)
+          .filter((n) => n.nodeType === Node.TEXT_NODE)
+          .map((n) => n.textContent)
+          .join('');
+        a.textContent = rawText.replace(/#/g, '').trim();
         a.className =
           'toc-link block truncate py-1 pl-3 border-l-2 border-transparent text-muted-foreground transition-all duration-150 hover:text-foreground';
 

--- a/src/components/article/ArticleTOC.astro
+++ b/src/components/article/ArticleTOC.astro
@@ -16,7 +16,7 @@ const t = useTranslations(defaultLang);
 
 {
   mode === 'mobile' ? (
-    <details class="toc-root border-border mb-6 rounded-md border xl:hidden">
+    <details class="toc-root border-border mb-6 rounded-md border">
       <summary class="font-code text-muted-foreground cursor-pointer px-4 py-2.5 text-xs select-none">
         {t('toc.title')}
       </summary>

--- a/src/components/article/RelatedArticles.astro
+++ b/src/components/article/RelatedArticles.astro
@@ -21,20 +21,9 @@ const { posts } = Astro.props;
         {posts.map((post) => (
           <a
             href={`/blog/${post.id}`}
-            class="bg-surface-elevated border-border-elevated group flex overflow-hidden rounded-lg border shadow-sm transition-shadow duration-200 hover:shadow-md"
+            class="bg-surface-elevated border-border-elevated group rounded-lg border p-3 shadow-sm transition-shadow duration-200 hover:shadow-md md:p-4"
           >
-            <img
-              src={
-                post.data.heroImage ??
-                `/api/og/article/${post.collection}/${post.id}.png`
-              }
-              alt=""
-              width={160}
-              height={84}
-              loading="lazy"
-              class="bg-muted hidden h-auto w-[120px] shrink-0 object-cover sm:block"
-            />
-            <div class="p-3 md:p-4">
+            <div>
               <span class="text-muted-foreground mb-1 block text-xs">
                 <span class="bg-muted rounded px-1.5 py-0.5 capitalize">
                   {post.data.category}

--- a/src/components/article/RelatedArticles.astro
+++ b/src/components/article/RelatedArticles.astro
@@ -21,7 +21,7 @@ const { posts } = Astro.props;
         {posts.map((post) => (
           <a
             href={`/blog/${post.id}`}
-            class="bg-surface-elevated border-border-elevated group overflow-hidden rounded-lg border shadow-sm transition-shadow duration-200 hover:shadow-md"
+            class="bg-surface-elevated border-border-elevated group flex overflow-hidden rounded-lg border shadow-sm transition-shadow duration-200 hover:shadow-md"
           >
             <img
               src={
@@ -29,10 +29,10 @@ const { posts } = Astro.props;
                 `/api/og/article/${post.collection}/${post.id}.png`
               }
               alt=""
-              width={600}
-              height={315}
+              width={160}
+              height={84}
               loading="lazy"
-              class="bg-muted aspect-[1200/630] w-full object-cover"
+              class="bg-muted hidden h-auto w-[120px] shrink-0 object-cover sm:block"
             />
             <div class="p-3 md:p-4">
               <span class="text-muted-foreground mb-1 block text-xs">

--- a/src/components/article/RelatedArticles.astro
+++ b/src/components/article/RelatedArticles.astro
@@ -13,25 +13,31 @@ const { posts } = Astro.props;
 
 {
   posts.length > 0 && (
-    <aside class="border-border mt-12 border-t pt-8">
-      <h2 class="font-code text-muted-foreground mb-4 text-xs">related</h2>
-      <ul class="space-y-3">
+    <aside class="mt-12 pt-8">
+      <h2 class="font-heading text-foreground mb-4 text-base font-semibold">
+        Related
+      </h2>
+      <div class="grid gap-3 sm:grid-cols-2">
         {posts.map((post) => (
-          <li>
-            <a href={`/blog/${post.id}`} class="group block">
-              <span
-                class="font-heading text-foreground group-hover:text-link text-sm transition-colors"
-                data-budoux
-              >
-                <Budoux text={post.data.title} />
+          <a
+            href={`/blog/${post.id}`}
+            class="bg-surface-elevated border-border-elevated group rounded-lg border p-4 shadow-sm transition-shadow duration-200 hover:shadow-md"
+          >
+            <span class="text-muted-foreground mb-1 block text-xs">
+              <span class="bg-muted rounded px-1.5 py-0.5 capitalize">
+                {post.data.category}
               </span>
-              <span class="font-code text-muted-foreground ml-2 text-xs">
-                {formatDateEn(post.data.published)}
-              </span>
-            </a>
-          </li>
+              <span class="ml-2">{formatDateEn(post.data.published)}</span>
+            </span>
+            <span
+              class="font-heading text-foreground group-hover:text-link line-clamp-2 text-sm leading-snug font-medium transition-colors"
+              data-budoux
+            >
+              <Budoux text={post.data.title} />
+            </span>
+          </a>
         ))}
-      </ul>
+      </div>
     </aside>
   )
 }

--- a/src/components/article/RelatedArticles.astro
+++ b/src/components/article/RelatedArticles.astro
@@ -17,29 +17,32 @@ const { posts } = Astro.props;
       <h2 class="font-heading text-foreground mb-4 text-base font-semibold">
         Related
       </h2>
-      <div class="grid gap-3 sm:grid-cols-2">
+      <ul class="space-y-3">
         {posts.map((post) => (
-          <a
-            href={`/blog/${post.id}`}
-            class="bg-surface-elevated border-border-elevated group rounded-lg border p-3 shadow-sm transition-shadow duration-200 hover:shadow-md md:p-4"
-          >
-            <div>
-              <span class="text-muted-foreground mb-1 block text-xs">
+          <li>
+            <a
+              href={`/blog/${post.id}`}
+              class="border-border group hover:border-accent-line hover:bg-surface-sunken block rounded-lg border-l-2 py-2 pr-3 pl-4 transition-all duration-200"
+            >
+              <span class="text-muted-foreground flex items-center gap-2 text-xs">
                 <span class="bg-muted rounded px-1.5 py-0.5 capitalize">
                   {post.data.category}
                 </span>
-                <span class="ml-2">{formatDateEn(post.data.published)}</span>
+                {formatDateEn(post.data.published)}
               </span>
               <span
-                class="font-heading text-foreground group-hover:text-link line-clamp-2 text-sm leading-snug font-medium transition-colors"
+                class="font-heading text-foreground group-hover:text-link mt-1 block text-sm leading-snug font-medium transition-colors"
                 data-budoux
               >
                 <Budoux text={post.data.title} />
               </span>
-            </div>
-          </a>
+              <span class="text-muted-foreground mt-0.5 line-clamp-1 block text-xs leading-relaxed">
+                {post.data.description}
+              </span>
+            </a>
+          </li>
         ))}
-      </div>
+      </ul>
     </aside>
   )
 }

--- a/src/components/article/RelatedArticles.astro
+++ b/src/components/article/RelatedArticles.astro
@@ -21,20 +21,33 @@ const { posts } = Astro.props;
         {posts.map((post) => (
           <a
             href={`/blog/${post.id}`}
-            class="bg-surface-elevated border-border-elevated group rounded-lg border p-4 shadow-sm transition-shadow duration-200 hover:shadow-md"
+            class="bg-surface-elevated border-border-elevated group overflow-hidden rounded-lg border shadow-sm transition-shadow duration-200 hover:shadow-md"
           >
-            <span class="text-muted-foreground mb-1 block text-xs">
-              <span class="bg-muted rounded px-1.5 py-0.5 capitalize">
-                {post.data.category}
+            <img
+              src={
+                post.data.heroImage ??
+                `/api/og/article/${post.collection}/${post.id}.png`
+              }
+              alt=""
+              width={600}
+              height={315}
+              loading="lazy"
+              class="bg-muted aspect-[1200/630] w-full object-cover"
+            />
+            <div class="p-3 md:p-4">
+              <span class="text-muted-foreground mb-1 block text-xs">
+                <span class="bg-muted rounded px-1.5 py-0.5 capitalize">
+                  {post.data.category}
+                </span>
+                <span class="ml-2">{formatDateEn(post.data.published)}</span>
               </span>
-              <span class="ml-2">{formatDateEn(post.data.published)}</span>
-            </span>
-            <span
-              class="font-heading text-foreground group-hover:text-link line-clamp-2 text-sm leading-snug font-medium transition-colors"
-              data-budoux
-            >
-              <Budoux text={post.data.title} />
-            </span>
+              <span
+                class="font-heading text-foreground group-hover:text-link line-clamp-2 text-sm leading-snug font-medium transition-colors"
+                data-budoux
+              >
+                <Budoux text={post.data.title} />
+              </span>
+            </div>
           </a>
         ))}
       </div>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -112,18 +112,11 @@ const relatedPosts = getRelatedPosts(post, publishedPosts);
 
     <ArticleTOC mode="mobile" />
 
-    <div class="xl:grid xl:grid-cols-[1fr_180px] xl:gap-8">
-      <article>
-        <Content components={components} />
-        <ShareButtons url={fullUrl} title={post.data.title} />
-        <RelatedArticles posts={relatedPosts} />
-      </article>
-      <aside class="hidden xl:block">
-        <div class="sticky top-20">
-          <ArticleTOC mode="desktop" />
-        </div>
-      </aside>
-    </div>
+    <article>
+      <Content components={components} />
+      <ShareButtons url={fullUrl} title={post.data.title} />
+      <RelatedArticles posts={relatedPosts} />
+    </article>
   </div>
   <ScrollToTop />
   <script is:inline slot="page-scripts">

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -54,8 +54,6 @@ const site = Astro.site ?? '';
 const path = `${post.collection}/${post.id}`;
 const fullUrl = new URL(path, site).toString();
 const t = useTranslations(defaultLang);
-const defaultImagePath = `/api/og/article/${post.collection}/${post.id}.png`;
-
 const relatedPosts = getRelatedPosts(post, publishedPosts);
 ---
 
@@ -92,34 +90,38 @@ const relatedPosts = getRelatedPosts(post, publishedPosts);
 >
   <ReadingProgress />
   <div>
-    {/* Header section: full-width, centered */}
-    <header class="mb-6">
-      <h1 class="font-heading text-center [text-wrap:wrap]" data-budoux>
+    <header class="mb-8">
+      <h1
+        class="font-heading text-foreground text-2xl leading-snug font-bold md:text-3xl"
+        data-budoux
+      >
         <Budoux text={post.data.title} />
       </h1>
       <ArticleHeader post={post} minRead={remarkPluginFrontmatter.minRead} />
-      <Image
-        class="my-3 rounded-md"
-        src={post.data.heroImage ?? defaultImagePath}
-        alt={`${post.data.title} のヒーロー画像`}
-        width={1200}
-        height={630}
-        loading="eager"
-        fetchpriority="high"
-      />
+      {
+        post.data.heroImage && (
+          <Image
+            class="mt-4 rounded-lg"
+            src={post.data.heroImage}
+            alt={`${post.data.title} のヒーロー画像`}
+            width={1200}
+            height={630}
+            loading="eager"
+            fetchpriority="high"
+          />
+        )
+      }
     </header>
 
-    {/* Mobile TOC */}
     <ArticleTOC mode="mobile" />
 
-    {/* Content + sidebar TOC */}
-    <div class="lg:grid lg:grid-cols-[1fr_200px] lg:gap-8">
+    <div class="xl:grid xl:grid-cols-[1fr_180px] xl:gap-8">
       <article>
         <Content components={components} />
         <ShareButtons url={fullUrl} title={post.data.title} />
         <RelatedArticles posts={relatedPosts} />
       </article>
-      <aside class="hidden lg:block">
+      <aside class="hidden xl:block">
         <div class="sticky top-20">
           <ArticleTOC mode="desktop" />
         </div>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -121,6 +121,28 @@ const relatedPosts = getRelatedPosts(post, publishedPosts);
   <ScrollToTop />
   <script is:inline slot="page-scripts">
     (function () {
+      document
+        .querySelectorAll('article :is(h2,h3,h4,h5,h6)[id] a')
+        .forEach(function (a) {
+          a.addEventListener('click', function (e) {
+            e.preventDefault();
+            const url =
+              location.origin + location.pathname + '#' + a.closest('[id]').id;
+            history.replaceState(null, '', '#' + a.closest('[id]').id);
+            navigator.clipboard.writeText(url).then(function () {
+              const icon = a.querySelector('.heading-link-icon');
+              if (icon) {
+                icon.dataset.original = icon.style.cssText;
+                icon.style.opacity = '1';
+                setTimeout(function () {
+                  icon.style.cssText = icon.dataset.original || '';
+                }, 1500);
+              }
+            });
+          });
+        });
+    })();
+    (function () {
       const els = document.querySelectorAll('pre.mermaid');
       if (els.length === 0) return;
       const s = document.createElement('script');

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -98,19 +98,16 @@ const relatedPosts = getRelatedPosts(post, publishedPosts);
         <Budoux text={post.data.title} />
       </h1>
       <ArticleHeader post={post} minRead={remarkPluginFrontmatter.minRead} />
-      {
-        post.data.heroImage && (
-          <Image
-            class="mt-4 rounded-lg"
-            src={post.data.heroImage}
-            alt={`${post.data.title} のヒーロー画像`}
-            width={1200}
-            height={630}
-            loading="eager"
-            fetchpriority="high"
-          />
-        )
-      }
+      <Image
+        class="mt-4 rounded-lg"
+        src={post.data.heroImage ??
+          `/api/og/article/${post.collection}/${post.id}.png`}
+        alt={`${post.data.title} のアイキャッチ`}
+        width={1200}
+        height={630}
+        loading="eager"
+        fetchpriority="high"
+      />
     </header>
 
     <ArticleTOC mode="mobile" />

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -98,16 +98,19 @@ const relatedPosts = getRelatedPosts(post, publishedPosts);
         <Budoux text={post.data.title} />
       </h1>
       <ArticleHeader post={post} minRead={remarkPluginFrontmatter.minRead} />
-      <Image
-        class="mt-4 rounded-lg"
-        src={post.data.heroImage ??
-          `/api/og/article/${post.collection}/${post.id}.png`}
-        alt={`${post.data.title} のアイキャッチ`}
-        width={1200}
-        height={630}
-        loading="eager"
-        fetchpriority="high"
-      />
+      {
+        post.data.heroImage && (
+          <Image
+            class="mt-4 rounded-lg"
+            src={post.data.heroImage}
+            alt={`${post.data.title} のアイキャッチ`}
+            width={1200}
+            height={630}
+            loading="eager"
+            fetchpriority="high"
+          />
+        )
+      }
     </header>
 
     <ArticleTOC mode="mobile" />

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -25,15 +25,33 @@ body {
     }
 
     & ul {
-      @apply list-disc pl-5;
+      @apply my-5 list-disc pl-6;
+
+      & ul {
+        @apply my-1 list-[circle] pl-5;
+      }
+
+      & ul ul {
+        list-style-type: '–  ';
+      }
     }
+
     & ol {
-      @apply list-decimal pl-5;
+      @apply my-5 list-decimal pl-6;
+
+      & ol {
+        @apply my-1 pl-5;
+        list-style-type: lower-alpha;
+      }
     }
+
     & li {
-      @apply list-outside;
-      @apply my-1.5;
+      @apply my-2 list-outside leading-relaxed;
       text-wrap: pretty;
+
+      &::marker {
+        @apply text-muted-foreground;
+      }
     }
 
     /* Heading hierarchy */

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -25,11 +25,10 @@ body {
     }
 
     & ul {
-      @apply my-5 pl-4;
-      list-style-type: '–  ';
+      @apply my-5 list-disc pl-6;
 
       & ul {
-        @apply my-1 pl-4;
+        @apply my-1 list-[circle] pl-5;
       }
     }
 
@@ -49,6 +48,10 @@ body {
     & li {
       @apply my-2 leading-relaxed;
       text-wrap: pretty;
+
+      &::marker {
+        @apply text-muted-foreground/60;
+      }
     }
 
     /* Heading hierarchy */

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -208,8 +208,13 @@ body {
 
     /* YouTube embed (astro-embed lite-youtube) */
     & lite-youtube {
-      @apply not-prose my-8 block w-full max-w-none rounded-lg;
+      @apply my-8 block w-full max-w-none rounded-lg;
       aspect-ratio: 16 / 9;
+
+      & a {
+        color: inherit;
+        text-decoration: none;
+      }
     }
 
     & figure {

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -25,7 +25,8 @@ body {
     }
 
     & ul {
-      @apply my-5 list-none pl-4;
+      @apply my-5 pl-4;
+      list-style-type: '–  ';
 
       & ul {
         @apply my-1 pl-4;

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -208,14 +208,8 @@ body {
 
     /* YouTube embed (astro-embed lite-youtube) */
     & lite-youtube {
-      @apply my-8 block w-full max-w-none overflow-hidden rounded-lg;
+      @apply not-prose my-8 block w-full max-w-none rounded-lg;
       aspect-ratio: 16 / 9;
-      background-size: cover;
-      background-position: center;
-
-      & a {
-        @apply text-transparent no-underline;
-      }
     }
 
     & figure {

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -208,8 +208,14 @@ body {
 
     /* YouTube embed (astro-embed lite-youtube) */
     & lite-youtube {
-      @apply my-8 w-full max-w-none rounded-lg;
+      @apply my-8 block w-full max-w-none overflow-hidden rounded-lg;
       aspect-ratio: 16 / 9;
+      background-size: cover;
+      background-position: center;
+
+      & a {
+        @apply text-transparent no-underline;
+      }
     }
 
     & figure {

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -21,7 +21,6 @@ body {
 
     & p {
       @apply my-5;
-      max-width: 38em;
       text-wrap: pretty;
     }
 
@@ -126,24 +125,62 @@ body {
       @apply my-5 overflow-x-auto rounded-md text-xs md:text-sm;
     }
     & blockquote {
-      @apply border-border bg-muted text-muted-foreground my-5 rounded-r-md border-l-2 py-3 pr-3 pl-4 not-italic;
+      @apply border-accent-line bg-surface-sunken my-5 rounded-r-md border-l-2 py-3 pr-4 pl-4 not-italic;
+      @apply text-foreground text-sm md:text-base;
+
+      & p {
+        @apply my-2;
+      }
+
+      & p:first-child {
+        @apply mt-0;
+      }
+
+      & p:last-child {
+        @apply mb-0;
+      }
     }
+
     & .footnotes {
-      @apply border-border text-muted-foreground mt-8 border-t pt-5 text-xs md:text-sm;
+      @apply border-border text-muted-foreground mt-10 border-t pt-5 text-xs md:text-sm;
+
+      & ol {
+        @apply pl-4;
+      }
+
+      & li {
+        @apply my-2;
+      }
+
       & .data-footnote-backref {
-        text-decoration: none;
+        @apply text-link no-underline;
       }
     }
 
     /* Tables */
+    & .table-wrapper {
+      @apply my-5 overflow-x-auto;
+    }
+
     & table {
       @apply my-5 w-full text-xs md:text-sm;
     }
+
     & th {
       @apply bg-muted px-2 py-2 text-left font-medium md:px-3;
+      white-space: nowrap;
     }
+
     & td {
       @apply border-border border-t px-2 py-2 md:px-3;
+    }
+
+    & tr {
+      @apply transition-colors;
+
+      &:hover {
+        @apply bg-muted/50;
+      }
     }
 
     /* Images and figures */
@@ -153,16 +190,19 @@ body {
 
     /* YouTube embed (astro-embed lite-youtube) */
     & lite-youtube {
-      @apply my-8 w-full max-w-none rounded-md;
+      @apply my-8 w-full max-w-none rounded-lg;
       aspect-ratio: 16 / 9;
     }
+
     & figure {
-      @apply my-5;
+      @apply my-6;
+
       & img {
         @apply my-0;
       }
+
       & figcaption {
-        @apply text-muted-foreground mt-2 text-center text-xs;
+        @apply text-muted-foreground mt-3 text-center text-xs leading-relaxed;
       }
     }
   }

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -25,14 +25,23 @@ body {
     }
 
     & ul {
-      @apply my-5 list-disc pl-6;
+      @apply my-5 list-none pl-0;
 
-      & ul {
-        @apply my-1 list-[circle] pl-5;
+      & > li {
+        @apply relative pl-4;
+
+        &::before {
+          content: '';
+          @apply bg-muted-foreground/40 absolute top-[0.7em] left-0 size-1 rounded-full;
+        }
       }
 
-      & ul ul {
-        list-style-type: '–  ';
+      & ul {
+        @apply my-1 pl-3;
+
+        & > li::before {
+          @apply bg-muted-foreground/25 size-[3px];
+        }
       }
     }
 
@@ -46,7 +55,7 @@ body {
     }
 
     & li {
-      @apply my-2 list-outside leading-relaxed;
+      @apply my-2 leading-relaxed;
       text-wrap: pretty;
 
       &::marker {

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -103,15 +103,15 @@ body {
       a > span.heading-link-icon {
         &:after {
           content: '#';
-          @apply text-muted-foreground ml-2 text-base transition-colors;
+          @apply text-muted-foreground mr-1.5 text-base transition-colors;
           transition-duration: var(--duration-fast);
-          opacity: 0.4;
+          opacity: 0;
         }
       }
       &:hover {
         a > span.heading-link-icon {
           &:after {
-            opacity: 1;
+            opacity: 0.6;
           }
         }
       }

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -25,23 +25,14 @@ body {
     }
 
     & ul {
-      @apply my-5 list-none pl-0;
-
-      & > li {
-        @apply relative pl-4;
-
-        &::before {
-          content: '';
-          @apply bg-muted-foreground/40 absolute top-[0.7em] left-0 size-1 rounded-full;
-        }
-      }
+      @apply my-5 list-disc pl-6;
 
       & ul {
-        @apply my-1 pl-3;
+        @apply my-1 list-[circle] pl-5;
+      }
 
-        & > li::before {
-          @apply bg-muted-foreground/25 size-[3px];
-        }
+      & ul ul {
+        list-style-type: '–  ';
       }
     }
 
@@ -55,7 +46,7 @@ body {
     }
 
     & li {
-      @apply my-2 leading-relaxed;
+      @apply my-2 list-outside leading-relaxed;
       text-wrap: pretty;
 
       &::marker {

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -25,19 +25,19 @@ body {
     }
 
     & ul {
-      @apply my-5 list-disc pl-6;
+      @apply my-5 list-none pl-4;
 
       & ul {
-        @apply my-1 list-[circle] pl-5;
-      }
-
-      & ul ul {
-        list-style-type: '–  ';
+        @apply my-1 pl-4;
       }
     }
 
     & ol {
       @apply my-5 list-decimal pl-6;
+
+      &::marker {
+        @apply text-muted-foreground;
+      }
 
       & ol {
         @apply my-1 pl-5;
@@ -46,12 +46,8 @@ body {
     }
 
     & li {
-      @apply my-2 list-outside leading-relaxed;
+      @apply my-2 leading-relaxed;
       text-wrap: pretty;
-
-      &::marker {
-        @apply text-muted-foreground;
-      }
     }
 
     /* Heading hierarchy */


### PR DESCRIPTION
## Summary

記事ページの UX 改善: 見出しリンク復活、シェアボタン統一、関連記事カード化、リスト・TOC・タグのスタイル刷新。

### 見出し URL コピー

- `rehype-slug` を追加して見出し ID 生成を修正（`rehype-autolink-headings` が動作していなかった）
- prepend 方式（見出しの左に `#`）に変更
- ホバー時のみ `#` を表示（opacity 0 → 0.6）
- クリックで URL + hash をクリップボードにコピー

### シェアボタン

- アイコンのみ → ボーダー付きピル + ラベル（X, Facebook, Hatena, Copy）
- タグ Badge と同じ border-border スタイルで統一

### 関連記事

- テキストリンク → カード形式（sm:grid-cols-2）
- OG 画像サムネイル（左 120px サイドバー、モバイル非表示）
- カテゴリバッジ + 日付 + タイトル（line-clamp-2）

### TOC

- `bg-surface-sunken` + `rounded-lg` でブロック化
- `font-heading font-semibold` でタイトル統一
- 初期展開（`open`）で目次が即座に見える

### タグ

- `#text` リンク → ボーダー付き Badge ピルにリデザイン

### メタ情報アイコン

- カレンダー（published）、回転矢印（updated）、時計（min read）SVG アイコン追加

### 箇条書き

- ネスト時のマーカー変化（disc → circle → dash）
- マーカー色を `text-muted-foreground` に
- 行間拡大（`leading-relaxed`）

### アイキャッチ

- OG 画像フォールバックを復元（heroImage がない場合）

## Test plan

- [x] `pnpm astro check` — 0 errors
- [x] デスクトップ: 見出し hover で # 表示、クリックで URL コピー
- [x] デスクトップ/ダーク: 全要素の色味確認
- [x] シェアボタン: X, Facebook, Hatena, Copy のラベル付きピル表示
- [x] 関連記事: OG サムネイル + カテゴリ + タイトル表示
- [ ] モバイル: レスポンシブ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
