### PR TITLE
feat: home card grid + disable rehypeBudoux for body text

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -11,7 +11,6 @@ import { h } from 'hastscript';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeMermaid from 'rehype-mermaid';
 
-import rehypeBudoux from './src/lib/rehype-budoux';
 import rehypeUnwrapSvgP from './src/lib/rehype-unwrap-svg-p';
 import remarkLink from './src/lib/remark-link';
 import { remarkReadingTime } from './src/lib/remark-reading-time';
@@ -82,7 +81,7 @@ export default defineConfig({
         },
       ],
       rehypeUnwrapSvgP,
-      rehypeBudoux,
+      // rehypeBudoux,
     ],
   },
   site: 'https://www.funailog.com',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -72,37 +72,28 @@ const otherPosts = recentPosts.slice(1);
 
     <!-- 最新記事セクション -->
     <section>
-      <h2 class="font-heading mb-6 text-lg">{t('index.latestPosts')}</h2>
+      <h2 class="font-heading mb-6 text-lg font-semibold">
+        {t('index.latestPosts')}
+      </h2>
 
-      {/* Featured post - Card style if has heroImage */}
       {
         featuredPost && (
-          <div class="mb-6">
+          <div class="mb-4">
             <PostCard post={featuredPost} variant="card" />
           </div>
         )
       }
 
-      {/* Other posts - List style */}
-      <ul class="space-y-5">
-        {
-          otherPosts.map((post) => (
-            <li>
-              <PostCard post={post} variant="list" />
-            </li>
-          ))
-        }
-      </ul>
+      <div class="grid gap-4 sm:grid-cols-2">
+        {otherPosts.map((post) => <PostCard post={post} variant="card" />)}
+      </div>
 
-      <div class="mt-8">
+      <div class="mt-8 text-center">
         <a
           href="/blog"
-          class="group font-code text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 text-xs transition-colors"
+          class="border-border hover:bg-accent hover:text-accent-foreground text-muted-foreground inline-flex items-center gap-1.5 rounded-md border px-4 py-2 text-sm transition-colors"
         >
-          {t('index.viewAllPosts')}
-          <span class="transition-transform group-hover:translate-x-0.5"
-            >&rarr;</span
-          >
+          {t('index.viewAllPosts')} &rarr;
         </a>
       </div>
     </section>


### PR DESCRIPTION
## Summary

ホーム画面のカードグリッド化 + rehypeBudoux 本文除外。

### ホーム画面

- Featured 記事: 大きなカード（全幅）
- 残り 4 記事: 2x2 グリッド（sm:grid-cols-2）
- 「すべての記事を見る」: ボーダー付きボタン（中央配置）
- 見出しに font-semibold 追加

### rehypeBudoux

- 記事本文から除外（コメントアウト）
- text-wrap: pretty + word-break: auto-phrase で十分
- 見出し等の短いテキストは Astro `<Budoux>` コンポーネント経由で引き続き適用

## Test plan

- [x] `pnpm astro check` — 0 errors
- [ ] ホーム画面: カードグリッド表示確認
- [ ] 記事本文: BudouX なしでの折り返し確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
