### PR TITLE
fix: drop text-wrap: balance on mobile headings

### DIFF
--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -61,8 +61,13 @@ body {
     & h4,
     & h5,
     & h6 {
-      text-wrap: balance;
       word-break: normal;
+
+      /* `text-wrap: balance` は左右の行長を揃えるため、モバイルでは
+         1 行目の右に必ず隙間ができて読みにくい。デスクトップ幅でのみ有効化。 */
+      @media (min-width: 48rem) {
+        text-wrap: balance;
+      }
     }
     & h1 {
       @apply font-heading text-foreground mt-10 mb-5;


### PR DESCRIPTION
## Summary

- モバイル幅で見出しの `text-wrap: balance` を無効化し、`md:` (768px) 以上のみ適用する
- `balance` は左右の行長を揃える仕様上、2 行になる見出しの 1 行目右端に必ず隙間ができ、モバイルで「右が空いてる」と感じる原因になっていた
- `word-break: auto-phrase`（`:lang(ja)` h1-h4）は維持し、文節改行は継続する

## Background

レスポンシブで本文が読みにくいというフィードバックを受け、原因を切り分けたところ「右側の余白」の主犯は本文ではなく見出しの `text-wrap: balance` だった。デスクトップではバランスのとれた見栄えに寄与するため、メディアクエリで分岐する形に変更。

## Test plan

- [ ] モバイル幅（〜768px）で記事ページを開き、見出しが右端まで自然に流れることを確認
- [ ] デスクトップ幅（768px+）で見出しがバランス調整されたままであることを確認
- [ ] `pnpm build` が通ることを確認（ローカル確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
