### PR TITLE
fix: drop text-wrap: pretty on mobile body paragraphs

### DIFF
--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -21,7 +21,12 @@ body {
 
     & p {
       @apply my-5;
-      text-wrap: pretty;
+
+      /* `text-wrap: pretty` は孤児行を避けるため手前の行を早めに改行する。
+         モバイルの狭幅では右側の余白が目立つので、デスクトップ幅でのみ有効化。 */
+      @media (min-width: 48rem) {
+        text-wrap: pretty;
+      }
     }
 
     & ul {
@@ -47,7 +52,10 @@ body {
 
     & li {
       @apply my-2 leading-relaxed;
-      text-wrap: pretty;
+
+      @media (min-width: 48rem) {
+        text-wrap: pretty;
+      }
 
       &::marker {
         @apply text-muted-foreground/60;


### PR DESCRIPTION
## Summary

- 本文 `<p>` と `<li>` の `text-wrap: pretty` を `md:` (768px) 以上のみ適用に変更
- `pretty` は孤児行を避けるため先読みで手前の行を早めに改行する仕様で、モバイル狭幅では右側に文字 4-5 個分の余白が目立つ
- モバイルではブラウザの greedy 改行に任せて右端まで詰めるようにする

## Background

PR #137 で見出しの `text-wrap: balance` をモバイルで無効化したが、本文側でも同じ症状（右側に大きな余白）が残っていることがスクリーンショットで確認できた。`pretty` も同じ最適化の派生なので、同じ作戦で md+ 限定にする。

## Test plan

- [ ] モバイル幅で記事ページを開き、本文が右端まで自然に流れることを確認
- [ ] デスクトップ幅で本文の行末調整が従来通り効いていることを確認
- [ ] `pnpm build` が通ることを確認（ローカル確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
