### PR TITLE
perf: switch Portfolio CollapsibleRoles to client:idle

### DIFF
--- a/src/components/portfolio/WorkExperienceSection.astro
+++ b/src/components/portfolio/WorkExperienceSection.astro
@@ -128,14 +128,14 @@ const COLLAPSIBLE_THRESHOLD = 3;
                 work.roles.length > 0 &&
                 (work.roles.length >= COLLAPSIBLE_THRESHOLD ? (
                   <CollapsibleRoles
-                    client:load
+                    client:idle
                     roles={work.roles}
                     initialVisibleCount={2}
                     lang={lang}
                   />
                 ) : (
                   <CollapsibleRoles
-                    client:load
+                    client:idle
                     roles={work.roles}
                     initialVisibleCount={work.roles.length}
                     lang={lang}


### PR DESCRIPTION
## Summary

- Portfolio の `CollapsibleRoles` のハイドレーション戦略を `client:load` → `client:idle` に変更
- 初期表示に不要な JS を idle 中まで遅延させ、Portfolio ページの TBT を削減

## Background

`CollapsibleRoles` は職歴の「ロール展開」ボタンを持つインタラクティブ要素だが、初期表示時点では `initialVisibleCount` 件分の SSR コンテンツが既に見えており、展開ボタンを押すまで JS は不要。

`client:load` はページ読み込み完了直後に即ハイドレートするためメインスレッドを早期に占有する。`client:idle` (requestIdleCallback ベース) ならブラウザのアイドル時間まで遅延され、初期表示の体感速度・LCP・TBT に効く。

`★ Insight ─────────────────────────────────────`
- ユーザーが Portfolio を開いてから「ロール展開」ボタンを押すまでに数秒以上の余裕があるはず。idle で十分間に合う。
- 完全に遅延したい場合は client:visible（スクロール到達時）も選択肢だが、Portfolio は短いページで全体が視界に入りやすいため idle で十分。
`─────────────────────────────────────────────────`

## Test plan

- [ ] `/portfolio` を開いて職歴の「+N more roles」ボタンが展開できる
- [ ] DevTools Performance タブで初期 hydration が requestIdleCallback で遅延されていることを確認
- [ ] `pnpm build` が通る（ローカル確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
