### PR TITLE
fix: wrap prose.css in @layer base to stop bleeding into UI components

### DIFF
--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -1,244 +1,254 @@
 @reference "./theme.css";
 
-body {
-  article {
-    /* prose with responsive font size */
-    @apply prose dark:prose-invert max-w-none flex-grow break-words;
-    @apply text-sm md:text-base;
-
-    /* Japanese-optimized line height — slightly tighter on mobile
-       so a higher character count fits in view without feeling cramped */
-    line-height: 1.7;
-
-    @media (min-width: 48rem) {
-      line-height: 1.8;
-    }
-
-    /* Let JA punctuation hang at line end for cleaner right edges
-       (Safari only) and opt into browser's default JA spacing trim */
-    hanging-punctuation: allow-end;
-    text-spacing-trim: normal;
-
-    & p {
-      @apply my-5;
-
-      /* `text-wrap: pretty` は孤児行を避けるため手前の行を早めに改行する。
-         モバイルの狭幅では右側の余白が目立つので、デスクトップ幅でのみ有効化。 */
-      @media (min-width: 48rem) {
-        text-wrap: pretty;
-      }
-    }
-
-    & ul {
-      @apply my-5 list-disc pl-6;
-
-      & ul {
-        @apply my-1 list-[circle] pl-5;
-      }
-    }
-
-    & ol {
-      @apply my-5 list-decimal pl-6;
-
-      &::marker {
-        @apply text-muted-foreground;
-      }
-
-      & ol {
-        @apply my-1 pl-5;
-        list-style-type: lower-alpha;
-      }
-    }
-
-    & li {
-      @apply my-2 leading-relaxed;
-
-      @media (min-width: 48rem) {
-        text-wrap: pretty;
-      }
-
-      &::marker {
-        @apply text-muted-foreground/60;
-      }
-    }
-
-    /* Heading hierarchy */
-    & h1,
-    & h2,
-    & h3,
-    & h4,
-    & h5,
-    & h6 {
-      word-break: normal;
-
-      /* `text-wrap: balance` は左右の行長を揃えるため、モバイルでは
-         1 行目の右に必ず隙間ができて読みにくい。デスクトップ幅でのみ有効化。 */
-      @media (min-width: 48rem) {
-        text-wrap: balance;
-      }
-    }
-    & h1 {
-      @apply font-heading text-foreground mt-10 mb-5;
-      @apply text-xl md:text-2xl;
-      font-weight: 700;
-      letter-spacing: -0.01em;
-    }
-    & h2 {
-      @apply font-heading text-foreground mt-8 mb-3;
-      @apply text-lg md:text-xl;
-      font-weight: 600;
-    }
-    & h3 {
-      @apply font-heading text-foreground mt-6 mb-2;
-      @apply text-base md:text-lg;
-      font-weight: 600;
-    }
-    & h4 {
-      @apply font-heading text-foreground mt-5 mb-2;
+/* `@layer base` でラップして、Tailwind ユーティリティ（utilities レイヤ）が
+   prose 子孫セレクタ（body article h3 等）を上書きできるようにする。
+   未ラップだと素のルールがレイヤ付き utilities に勝つため、AffiliateCard
+   のような UI コンポーネントに記事本文用のスタイルが漏れていた。 */
+@layer base {
+  body {
+    article {
+      /* prose with responsive font size */
+      @apply prose dark:prose-invert max-w-none flex-grow break-words;
       @apply text-sm md:text-base;
-      font-weight: 600;
-    }
-    & h5 {
-      @apply font-heading text-foreground mt-4 mb-1;
-      @apply text-sm;
-      font-weight: 500;
-    }
-    & h6 {
-      @apply font-heading text-foreground mt-3 mb-1;
-      @apply text-xs md:text-sm;
-      font-weight: 500;
-    }
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      a > span.heading-link-icon {
-        &:after {
-          content: '#';
-          @apply text-muted-foreground mr-1.5 text-base transition-colors;
-          transition-duration: var(--duration-fast);
-          opacity: 0;
-        }
+
+      /* Japanese-optimized line height — slightly tighter on mobile
+       so a higher character count fits in view without feeling cramped */
+      line-height: 1.7;
+
+      @media (min-width: 48rem) {
+        line-height: 1.8;
       }
-      &:hover {
-        a > span.heading-link-icon {
-          &:after {
-            opacity: 0.6;
-          }
-        }
-      }
-    }
-    & a {
-      @apply text-link underline underline-offset-3 transition-[color,text-decoration-color];
-      /* Fallback for browsers without color-mix() (Safari < 16.2) */
-      text-decoration-color: var(--color-link);
-      /* Modern browsers: 40% opacity via color-mix */
-      text-decoration-color: color-mix(in oklab, currentColor 40%, transparent);
-      transition-duration: var(--duration-fast);
-      &:hover {
-        @apply text-link-hover;
-        text-decoration-color: currentColor;
-      }
-    }
-    & code {
-      @apply bg-muted font-code rounded px-1.5 py-0.5 text-xs md:text-sm;
-    }
-    & p code,
-    & li code,
-    & td code {
-      &::before,
-      &::after {
-        content: none !important;
-      }
-    }
-    & pre {
-      @apply my-5 overflow-x-auto rounded-md text-xs md:text-sm;
-    }
-    & blockquote {
-      @apply border-accent-line bg-surface-sunken my-5 rounded-r-md border-l-2 py-3 pr-4 pl-4 not-italic;
-      @apply text-foreground text-sm md:text-base;
+
+      /* Let JA punctuation hang at line end for cleaner right edges
+       (Safari only) and opt into browser's default JA spacing trim */
+      hanging-punctuation: allow-end;
+      text-spacing-trim: normal;
 
       & p {
-        @apply my-2;
+        @apply my-5;
+
+        /* `text-wrap: pretty` は孤児行を避けるため手前の行を早めに改行する。
+         モバイルの狭幅では右側の余白が目立つので、デスクトップ幅でのみ有効化。 */
+        @media (min-width: 48rem) {
+          text-wrap: pretty;
+        }
       }
 
-      & p:first-child {
-        @apply mt-0;
-      }
+      & ul {
+        @apply my-5 list-disc pl-6;
 
-      & p:last-child {
-        @apply mb-0;
+        & ul {
+          @apply my-1 list-[circle] pl-5;
+        }
       }
-    }
-
-    & .footnotes {
-      @apply border-border text-muted-foreground mt-10 border-t pt-5 text-xs md:text-sm;
 
       & ol {
-        @apply pl-4;
+        @apply my-5 list-decimal pl-6;
+
+        &::marker {
+          @apply text-muted-foreground;
+        }
+
+        & ol {
+          @apply my-1 pl-5;
+          list-style-type: lower-alpha;
+        }
       }
 
       & li {
-        @apply my-2;
+        @apply my-2 leading-relaxed;
+
+        @media (min-width: 48rem) {
+          text-wrap: pretty;
+        }
+
+        &::marker {
+          @apply text-muted-foreground/60;
+        }
       }
 
-      & .data-footnote-backref {
-        @apply text-link no-underline;
+      /* Heading hierarchy */
+      & h1,
+      & h2,
+      & h3,
+      & h4,
+      & h5,
+      & h6 {
+        word-break: normal;
+
+        /* `text-wrap: balance` は左右の行長を揃えるため、モバイルでは
+         1 行目の右に必ず隙間ができて読みにくい。デスクトップ幅でのみ有効化。 */
+        @media (min-width: 48rem) {
+          text-wrap: balance;
+        }
       }
-    }
-
-    /* Tables */
-    & .table-wrapper {
-      @apply -mx-4 my-5 overflow-x-auto px-4 md:mx-0 md:px-0;
-    }
-
-    & table {
-      @apply w-full min-w-[500px] text-xs md:min-w-0 md:text-sm;
-    }
-
-    & th {
-      @apply bg-muted px-2 py-2 text-left font-medium md:px-3;
-      white-space: nowrap;
-    }
-
-    & td {
-      @apply border-border border-t px-2 py-2 md:px-3;
-    }
-
-    & tr {
-      @apply transition-colors;
-
-      &:hover {
-        @apply bg-muted/50;
+      & h1 {
+        @apply font-heading text-foreground mt-10 mb-5;
+        @apply text-xl md:text-2xl;
+        font-weight: 700;
+        letter-spacing: -0.01em;
       }
-    }
-
-    /* Images and figures */
-    & img {
-      @apply my-5 rounded-md;
-    }
-
-    /* YouTube embed (astro-embed lite-youtube) */
-    & lite-youtube {
-      @apply my-8 block w-full max-w-none rounded-lg;
-      aspect-ratio: 16 / 9;
-
+      & h2 {
+        @apply font-heading text-foreground mt-8 mb-3;
+        @apply text-lg md:text-xl;
+        font-weight: 600;
+      }
+      & h3 {
+        @apply font-heading text-foreground mt-6 mb-2;
+        @apply text-base md:text-lg;
+        font-weight: 600;
+      }
+      & h4 {
+        @apply font-heading text-foreground mt-5 mb-2;
+        @apply text-sm md:text-base;
+        font-weight: 600;
+      }
+      & h5 {
+        @apply font-heading text-foreground mt-4 mb-1;
+        @apply text-sm;
+        font-weight: 500;
+      }
+      & h6 {
+        @apply font-heading text-foreground mt-3 mb-1;
+        @apply text-xs md:text-sm;
+        font-weight: 500;
+      }
+      h2,
+      h3,
+      h4,
+      h5,
+      h6 {
+        a > span.heading-link-icon {
+          &:after {
+            content: '#';
+            @apply text-muted-foreground mr-1.5 text-base transition-colors;
+            transition-duration: var(--duration-fast);
+            opacity: 0;
+          }
+        }
+        &:hover {
+          a > span.heading-link-icon {
+            &:after {
+              opacity: 0.6;
+            }
+          }
+        }
+      }
       & a {
-        color: inherit;
-        text-decoration: none;
+        @apply text-link underline underline-offset-3 transition-[color,text-decoration-color];
+        /* Fallback for browsers without color-mix() (Safari < 16.2) */
+        text-decoration-color: var(--color-link);
+        /* Modern browsers: 40% opacity via color-mix */
+        text-decoration-color: color-mix(
+          in oklab,
+          currentColor 40%,
+          transparent
+        );
+        transition-duration: var(--duration-fast);
+        &:hover {
+          @apply text-link-hover;
+          text-decoration-color: currentColor;
+        }
       }
-    }
+      & code {
+        @apply bg-muted font-code rounded px-1.5 py-0.5 text-xs md:text-sm;
+      }
+      & p code,
+      & li code,
+      & td code {
+        &::before,
+        &::after {
+          content: none !important;
+        }
+      }
+      & pre {
+        @apply my-5 overflow-x-auto rounded-md text-xs md:text-sm;
+      }
+      & blockquote {
+        @apply border-accent-line bg-surface-sunken my-5 rounded-r-md border-l-2 py-3 pr-4 pl-4 not-italic;
+        @apply text-foreground text-sm md:text-base;
 
-    & figure {
-      @apply my-6;
+        & p {
+          @apply my-2;
+        }
 
+        & p:first-child {
+          @apply mt-0;
+        }
+
+        & p:last-child {
+          @apply mb-0;
+        }
+      }
+
+      & .footnotes {
+        @apply border-border text-muted-foreground mt-10 border-t pt-5 text-xs md:text-sm;
+
+        & ol {
+          @apply pl-4;
+        }
+
+        & li {
+          @apply my-2;
+        }
+
+        & .data-footnote-backref {
+          @apply text-link no-underline;
+        }
+      }
+
+      /* Tables */
+      & .table-wrapper {
+        @apply -mx-4 my-5 overflow-x-auto px-4 md:mx-0 md:px-0;
+      }
+
+      & table {
+        @apply w-full min-w-[500px] text-xs md:min-w-0 md:text-sm;
+      }
+
+      & th {
+        @apply bg-muted px-2 py-2 text-left font-medium md:px-3;
+        white-space: nowrap;
+      }
+
+      & td {
+        @apply border-border border-t px-2 py-2 md:px-3;
+      }
+
+      & tr {
+        @apply transition-colors;
+
+        &:hover {
+          @apply bg-muted/50;
+        }
+      }
+
+      /* Images and figures */
       & img {
-        @apply my-0;
+        @apply my-5 rounded-md;
       }
 
-      & figcaption {
-        @apply text-muted-foreground mt-3 text-center text-xs leading-relaxed;
+      /* YouTube embed (astro-embed lite-youtube) */
+      & lite-youtube {
+        @apply my-8 block w-full max-w-none rounded-lg;
+        aspect-ratio: 16 / 9;
+
+        & a {
+          color: inherit;
+          text-decoration: none;
+        }
+      }
+
+      & figure {
+        @apply my-6;
+
+        & img {
+          @apply my-0;
+        }
+
+        & figcaption {
+          @apply text-muted-foreground mt-3 text-center text-xs leading-relaxed;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- `prose.css` 全体を `@layer base` で包み、Tailwind ユーティリティクラスが prose スタイルを正しく上書きできるようにする
- AffiliateCard など `not-prose` の UI コンポーネント内で、本文用 prose スタイルが漏れて見た目が崩れていた問題を修正

## Root cause

`prose.css` は `body article { & h3 {...} }` のような子孫セレクタで書かれていたが、**レイヤー指定なし** (`@layer` ラップ無し) だった。

Tailwind v4 ではユーティリティクラスが `@layer utilities` に入っており、CSS Cascade Layers の仕様で「**レイヤーありのスタイルはレイヤーなしのスタイルに負ける**」。結果、`body article h3 { font-weight: 600 }` (レイヤー無し) が `.font-medium` (utilities レイヤー) に勝っていた。

`not-prose` は `.prose` セレクタで書かれた Typography 公式ルールには効くが、`body article` 子孫セレクタには無力。

## Symptoms (before fix)

`/blog/2024/review-monitors-u4025qw-dell` の AffiliateCard で実測:

| 要素 | 意図 | 実際 |
|:--|:--|:--|
| `<h3>` (タイトル) | 16px / 500 / margin 0 | 18px / 600 / margin-top 24px |
| `<p>` (description) | margin 0 | margin-y 20px |
| `<img>` | margin 0 | margin-y 20px |
| `<a>` (Amazon/楽天ボタン) | no underline | underline 付き |

styleguide では article 配下ではないので prose ルールが当たらず、`/styleguide` と `/blog/...` で見た目が一致していなかった。

## Fix

`prose.css` を `@layer base { ... }` で包む。これで base レイヤーになり、utilities レイヤー (ユーティリティクラス) が優先される。

修正後、同じ URL で実測値が意図通りに戻ることを確認:
- h3: 16px / 500 / margin 0
- p: 14px / 400 / margin 0
- img: margin 0
- a: no underline

記事本文の h2 / p などは引き続き prose スタイルを受ける (utility class を持たないため):
- h2: 20px / 600 / mt-32px / font-heading
- p: 16px / 400 / my-20px

## Test plan

- [ ] `/blog/2024/review-monitors-u4025qw-dell` の AffiliateCard が `/styleguide` と同じ見た目
- [ ] 他のアフィリエイト記事 (best-buy-2025, mx-ergo, kanademono-desk) の AffiliateCard も同様
- [ ] 普通のブログ記事の見出し・本文の見た目に regression がない
- [ ] `pnpm build` が通る (ローカル確認済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
