### PR TITLE
chore(blog): SWE→SRE 記事を lifestyle カテゴリへ

### DIFF
--- a/src/content/blog/2026/swe-to-sre-foundation-spiral.mdx
+++ b/src/content/blog/2026/swe-to-sre-foundation-spiral.mdx
@@ -3,7 +3,7 @@ title: 基盤の面白さに、10年かけて気づいた ―― SWEからSREへ
 description: ファーストキャリアはネットワークエンジニア。そこからアプリ側のSWEを10年やって、また基盤側のSRE/Platform Engineerへ戻る。一周して気づいた「基盤を提供する面白さ」と、キャリアをどう考えているかを書きました。
 published: 2026-06-01
 isPublished: true
-category: programming
+category: lifestyle
 tags:
   - キャリア
   - SRE


### PR DESCRIPTION
## なぜ

`swe-to-sre-foundation-spiral.mdx` のカテゴリ `programming` が中身とズレていたため `lifestyle` に変更する。

技術 how-to ではなくキャリアの語り（半分エッセイ）であることは、記事自身が示している:

- 冒頭で「先に白状しておくと、これは半分ポエムです」と宣言
- 想定読者で「技術の how-to ではなく、キャリアの捉え方の話です」と明記
- コードブロックはゼロ。技術用語は実装ではなく経歴の素材として登場
- 締めが「## 最後に」= 体験記（lifestyle）の作法（`blog-writing-style.md`）。技術・ガジェット系の「総評」ではない

`programming` の定義（コード例・実装手順・なぜその技術が重要か）に当てはまらず、技術 how-to を期待した読者の期待値ともズレる。

## 変更

- `category: programming` → `category: lifestyle`（1行）
- タグ（SRE / Platform Engineer / エンジニアキャリア 等）は据え置き。タグ経由の流入は維持
- `lifestyle` は `src/schemas/blog-collection.ts` の enum に含まれる有効値

🤖 Generated with [Claude Code](https://claude.com/claude-code)