### PR TITLE
fix(blog): phrase-aware heading wrapping on iOS/WebKit

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -12,6 +12,7 @@ import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeMermaid from 'rehype-mermaid';
 import rehypeSlug from 'rehype-slug';
 
+import rehypeBudoux from './src/lib/rehype-budoux';
 import rehypeTableWrapper from './src/lib/rehype-table-wrapper';
 import rehypeUnwrapSvgP from './src/lib/rehype-unwrap-svg-p';
 import remarkLink from './src/lib/remark-link';
@@ -72,7 +73,7 @@ export default defineConfig({
       [
         rehypeAutolinkHeadings,
         {
-          behavior: 'prepend',
+          behavior: 'append',
           properties(node: Element) {
             return {
               'aria-labelledby': node.properties.id,
@@ -85,7 +86,10 @@ export default defineConfig({
       ],
       rehypeUnwrapSvgP,
       rehypeTableWrapper,
-      // rehypeBudoux,
+      // BudouX <wbr> for headings only: gives phrase-aware wrapping on all
+      // browsers (incl. iOS WebKit, where word-break: auto-phrase is ignored).
+      // Runs after autolink-headings; <a> is excluded so the # anchor stays atomic.
+      [rehypeBudoux, { includeTagNames: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] }],
     ],
   },
   site: 'https://www.funailog.com',

--- a/src/lib/rehype-budoux.test.ts
+++ b/src/lib/rehype-budoux.test.ts
@@ -5,10 +5,13 @@ import { describe, it, expect } from 'vitest';
 
 import rehypeBudoux from './rehype-budoux';
 
-async function process(html: string): Promise<string> {
+async function process(
+  html: string,
+  options: NonNullable<Parameters<typeof rehypeBudoux>[0]> = {},
+): Promise<string> {
   const file = await unified()
     .use(rehypeParse, { fragment: true })
-    .use(rehypeBudoux)
+    .use(rehypeBudoux, options)
     .use(rehypeStringify)
     .process(html);
   return String(file);
@@ -40,6 +43,31 @@ describe('rehypeBudoux', () => {
     const anchorInner = anchorMatch![1];
     expect(anchorInner).not.toContain('<wbr>');
     expect(anchorInner).toBe('公式ドキュメントを読みます');
+  });
+
+  it('with includeTagNames, segments only matching elements (headings), not paragraphs', async () => {
+    const output = await process(
+      '<h2>今日はいい天気ですね。</h2><p>今日はいい天気ですね。</p>',
+      { includeTagNames: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] },
+    );
+    const h2 = output.match(/<h2[\s\S]*?<\/h2>/)![0];
+    expect(h2).toContain('<wbr>');
+    expect(h2).toContain('data-budoux');
+    const p = output.match(/<p[\s\S]*?<\/p>/)![0];
+    expect(p).not.toContain('<wbr>');
+    expect(p).not.toContain('data-budoux');
+  });
+
+  it('with includeTagNames, segments heading text even when an anchor is present', async () => {
+    const output = await process(
+      '<h2><a href="#x"><span>#</span></a>今日はいい天気ですね。</h2>',
+      { includeTagNames: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] },
+    );
+    const h2 = output.match(/<h2[\s\S]*?<\/h2>/)![0];
+    expect(h2).toContain('<wbr>');
+    // the anchor content stays atomic
+    const anchorInner = h2.match(/<a[^>]*>([\s\S]*?)<\/a>/)![1];
+    expect(anchorInner).not.toContain('<wbr>');
   });
 
   it('does not insert <wbr> inside <a> with nested inline elements', async () => {

--- a/src/lib/rehype-budoux.ts
+++ b/src/lib/rehype-budoux.ts
@@ -8,6 +8,12 @@ import type { Plugin } from 'unified';
 
 interface Options {
   excludeTagNames?: string[];
+  /**
+   * When set, only segment text whose ancestor chain contains one of these
+   * tag names (e.g. ['h1','h2',...] to limit BudouX to headings). When unset,
+   * all text outside excludeTagNames is segmented.
+   */
+  includeTagNames?: string[];
 }
 
 const defaultExcludeTagNames = ['pre', 'code', 'a', 'svg'];
@@ -37,6 +43,7 @@ let parser: HTMLProcessingParser | null = null;
 
 const rehypeBudoux: Plugin<[Options?], Root> = ({
   excludeTagNames = defaultExcludeTagNames,
+  includeTagNames,
 }: Options = {}) => {
   return (tree) => {
     visitParents(tree, 'text', (node, ancestors) => {
@@ -51,6 +58,8 @@ const rehypeBudoux: Plugin<[Options?], Root> = ({
         parent.type !== 'element' ||
         matchesExcluded(parent, excludeTagNames) ||
         ancestors.some((a) => matchesExcluded(a, excludeTagNames)) ||
+        (includeTagNames !== undefined &&
+          !ancestors.some((a) => matchesExcluded(a, includeTagNames))) ||
         node.value.trim().length === 0
       ) {
         return;

--- a/src/styles/budoux.css
+++ b/src/styles/budoux.css
@@ -17,16 +17,19 @@ html:lang(ja) {
   word-break: auto-phrase;
 }
 
-/* BudouX-segmented text: prefer browser-native phrase wrapping
-   on Chrome 119+, with <wbr> as a break hint. Falls back to
-   word-break: normal in Safari — pretty line-wrap + wbr hints
-   still produce reasonable results.
+/* BudouX-segmented text (article titles, card titles): the <wbr> hints
+   from BudouX mark phrase boundaries. Pair them with word-break: keep-all
+   so EVERY browser breaks only at those boundaries. word-break: auto-phrase
+   is Chrome-only; Safari/iOS falls back to normal and breaks mid-phrase,
+   which made long headings wrap raggedly on mobile. keep-all + <wbr> gives
+   the same phrase wrapping everywhere. overflow-wrap: anywhere is the safety
+   valve for tokens with no break point; text-wrap: pretty trims orphans.
 
-   text-wrap: pretty reduces orphans and short last lines. Heading-
-   level balance lives in prose.css (article scope) and per-element
-   text-balance utilities (hero tagline, footer descriptions). */
-[data-budoux] {
-  word-break: auto-phrase;
+   The :lang(ja) [data-budoux] selector (specificity 0,2,0) intentionally
+   overrides the :lang(ja) h1–h4 rule above (0,1,1) for the article title. */
+[data-budoux],
+:lang(ja) [data-budoux] {
+  word-break: keep-all;
   overflow-wrap: anywhere;
   text-wrap: pretty;
 }

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -121,7 +121,7 @@
         a > span.heading-link-icon {
           &:after {
             content: '#';
-            @apply text-muted-foreground mr-1.5 text-base transition-colors;
+            @apply text-muted-foreground ml-1.5 text-base transition-colors;
             transition-duration: var(--duration-fast);
             opacity: 0;
           }


### PR DESCRIPTION
## 概要

iOS（全ブラウザが WebKit エンジン）で、長い日本語見出しが文節の途中で改行されて読みづらい問題を修正します。例: 「きっかけ：これは「チケット管理」だと気づいた」が「チ|ケット管理」で割れる。

## 原因

`word-break: auto-phrase` は Chrome 系専用で、iOS/WebKit では無効化され `normal`（任意位置で改行）にフォールバックする。本文見出しは BudouX 未適用（`<wbr>` なし）だったため、文節情報がなく任意の文字位置で折り返していた。

## 修正

- **`src/lib/rehype-budoux.ts`**: `includeTagNames` オプションを追加。見出しだけに BudouX を適用できるようにした（段落・表は対象外）。
- **`astro.config.ts`**: rehype-budoux を `['h1'..'h6']` 限定で有効化（autolink-headings の後段。`<a>` は除外されアンカーは非分割）。あわせて見出しアンカーを `prepend` → `append`。
- **`src/styles/budoux.css`**: `[data-budoux]` を `word-break: auto-phrase` → `keep-all`。`<wbr>` と併用し全ブラウザ（iOS 含む）が文節境界だけで折り返す。`:lang(ja) [data-budoux]`（詳細度 0,2,0）で `:lang(ja) h1–h4`（0,1,1）を上書きしタイトルにも適用。
- **`src/styles/prose.css`**: アンカー `#` の余白を `mr-1.5` → `ml-1.5`（末尾配置に合わせる）。

## 効果

見出しに文節境界で `<wbr>` が入り、iOS でも「チケット管理」が塊で維持される。記事タイトル・カードタイトルにも同じ phrase wrapping が効く。

## 検証

- vitest 114 passed（rehype-budoux に新規2件、TDD で Red→Green）
- eslint / astro check / tsc: 0 error
- `pnpm build` Complete（234 ページ）
- 生成 HTML で見出しの `data-budoux` ＋ `<wbr>`、アンカー append、`html lang="ja"` を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
