### PR TITLE
fix(blog): preducts 記事の Amazon リンクにアソシエイトタグを付与

### DIFF
--- a/src/content/blog/2023/preducts-first-impression.mdx
+++ b/src/content/blog/2023/preducts-first-impression.mdx
@@ -9,6 +9,8 @@ tags: ['desk', 'review', 'PREDUCTS', 'FlexiSpot', 'デスクツアー', 'DIY']
 category: gadgets
 ---
 
+※ 本記事にはアフィリエイトリンクが含まれます。
+
 PREDUCTSのデスクとFlexiSpot E7を組み合わせた昇降デスクの導入記録です。
 
 **この記事でわかること:**
@@ -38,9 +40,9 @@ https://preducts.jp/
 - [Tray L - type B (Black) - PREDUCTS](https://preducts.jp/products/tray-l-type-b)
 - [PC Mount (L) - PREDUCTS](https://preducts.jp/products/pc-mount?variant=42295292887212)
 - [Base Slider - PREDUCTS](https://preducts.jp/products/base-slider) x 3
-- [Murakoshi ムラコシ オニメD 【M5×13】 ≪5個1パック≫](https://www.amazon.co.jp/gp/product/B00AK475TK) x 3
-- [TRUSCO(トラスコ) 超低頭SUSキャップボルト M5×16 6本 Y311-0516](https://www.amazon.co.jp/gp/product/B0795CVG5M) x 2
-- [スターエム 5B-080 先三角ショートビット 8mm](https://www.amazon.co.jp/gp/product/B001WHBBQW)
+- [Murakoshi ムラコシ オニメD 【M5×13】 ≪5個1パック≫](https://www.amazon.co.jp/gp/product/B00AK475TK?tag=funailog-22) x 3
+- [TRUSCO(トラスコ) 超低頭SUSキャップボルト M5×16 6本 Y311-0516](https://www.amazon.co.jp/gp/product/B0795CVG5M?tag=funailog-22) x 2
+- [スターエム 5B-080 先三角ショートビット 8mm](https://www.amazon.co.jp/gp/product/B001WHBBQW?tag=funailog-22)
 - 木工用ボンド
 
 またFlexiSpotのE7を脚に利用するため別途購入しています。
@@ -77,7 +79,7 @@ https://ritalog0317.com/flexispot-diy-ritalog/
 
 ### Blue Spark SL
 
-https://www.amazon.co.jp/dp/B09R4GW3V6
+https://www.amazon.co.jp/dp/B09R4GW3V6?tag=funailog-22
 
 マイクはさておき、マイクスタンドがカッコいいとテンションが上がります。以前は安いマイクスタンドを使っていましたが、関節が壊れたのでこちらに買い替えました。
 マイクは比較的高級だと思いますが、あまり使い勝手は良くないです。
@@ -87,7 +89,7 @@ https://www.amazon.co.jp/dp/B09R4GW3V6
 
 ### AG06
 
-https://www.amazon.co.jp/dp/B09V7BFQV4
+https://www.amazon.co.jp/dp/B09V7BFQV4?tag=funailog-22
 
 多くの人に愛されているヤマハ製品のAG06です。昔ベースを弾いていたのでミキサーを持っています。
 もう8年選手とかなので、非常に長持ちしています。
@@ -115,7 +117,7 @@ HPのシークレットセールで購入した記憶があります。
 
 モニターアーム補強プレートを噛ませており、グラつきの低減とデスク保護をしています。
 
-https://www.amazon.co.jp/gp/product/B07SYPF134
+https://www.amazon.co.jp/gp/product/B07SYPF134?tag=funailog-22
 
 ### キーボード・マウス
 

--- a/src/data/link-cards.json
+++ b/src/data/link-cards.json
@@ -373,17 +373,20 @@
     "image": {},
     "title": "XDG Base Directory - ArchWiki"
   },
-  "https://www.amazon.co.jp/dp/B09R4GW3V6": {
+  "https://www.amazon.co.jp/dp/B09R4GW3V6?tag=funailog-22": {
+    "description": "Amazon.co.jp: Blue Microphones Spark SL XLR マイク コンデンサーマイク ショックマウント付き マイクスタンドセット [ BM1100BK + BM100CBK ] : 楽器・音響機器",
     "image": {},
-    "title": "Amazon.co.jp"
+    "title": "Amazon.co.jp: Blue Microphones Spark SL XLR マイク コンデンサーマイク ショックマウント付き マイクスタンドセット [ BM1100BK + BM100CBK ] : 楽器・音響機器"
   },
-  "https://www.amazon.co.jp/dp/B09V7BFQV4": {
+  "https://www.amazon.co.jp/dp/B09V7BFQV4?tag=funailog-22": {
+    "description": "ヤマハ(YAMAHA) ライブストリーミングミキサー 6チャンネル ホワイト AG06MK2 Wがミキサーストアでいつでもお買い得。当日お急ぎ便対象商品は、当日お届け可能です。アマゾン配送商品は、通常配送無料（一部除く）。",
     "image": {},
-    "title": "Amazon.co.jp"
+    "title": "Amazon | ヤマハ(YAMAHA) ライブストリーミングミキサー 6チャンネル ホワイト AG06MK2 W | ミキサー | 楽器・音響機器"
   },
-  "https://www.amazon.co.jp/gp/product/B07SYPF134": {
+  "https://www.amazon.co.jp/gp/product/B07SYPF134?tag=funailog-22": {
+    "description": "Amazon.co.jp: ZepSon モニターアーム補強プレート 取付部硬さ強化対策 デスク保護 傷防止 滑り止めシート付き 黒色 : パソコン・周辺機器",
     "image": {},
-    "title": "Amazon.co.jp"
+    "title": "Amazon.co.jp: ZepSon モニターアーム補強プレート 取付部硬さ強化対策 デスク保護 傷防止 滑り止めシート付き 黒色 : パソコン・周辺機器"
   },
   "https://www.amazon.com/dp/B0C14XCTCP?psc=1&ref=ppx_yo2ov_dt_b_product_details": {
     "image": {},


### PR DESCRIPTION
## 概要

PV 上位（直近 90 日で 2 位）の preducts 記事にある Amazon リンク 6 本が、
すべてアソシエイトタグ無しで未収益化になっていたため `?tag=funailog-22` を付与する。

## 変更内容

- Markdown リンク 3 本（DIY 部材: オニメD・キャップボルト・ショートビット）と裸 URL 3 本（Blue Spark SL・AG06・モニターアーム補強プレート）にタグを付与
- ステマ規制（2023年10月〜）対応として、本文冒頭にアフィリエイト開示を 1 行追加
- 裸 URL は LinkCard のキャッシュキーが URL 全体のため、`src/data/link-cards.json` の該当 3 エントリを `pnpm link-cards:warm` で再取得して更新

`lastUpdated` は本文内容の更新ではないため変更していない。

## 検証

- `pnpm lint`（textlint / markdownlint / prettier 含む）通過
- `pnpm build` exit 0（246 ページ）。ビルド後 HTML でタグ付き URL 6 本と開示文の出力を確認
- 再ビルドで `link-cards.json` に差分が出ないこと（冪等性）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
