### PR TITLE
fix(seo): JSON-LD の Organization @id を URL に修正し mainEntityOfPage を追加

### DIFF
--- a/src/lib/rich-results.test.ts
+++ b/src/lib/rich-results.test.ts
@@ -1,0 +1,72 @@
+import type { CollectionEntry } from 'astro:content';
+
+import { describe, expect, it } from 'vitest';
+
+import { ArticleLd, WebsiteLd } from './rich-results';
+
+const site = new URL('https://www.funailog.com/');
+
+const meta = {
+  collection: 'site',
+  id: 'meta',
+  data: {
+    main: { defaultImage: '/og-default.png' },
+    rss: { title: 'funailog', description: 'funailog rss' },
+    author: { name: 'paveg' },
+    links: {
+      github: 'https://github.com/paveg',
+      twitter: 'https://twitter.com/paveg_',
+      instagram: 'https://instagram.com/paveg',
+      linkedin: 'https://linkedin.com/in/paveg',
+    },
+  },
+} as unknown as CollectionEntry<'site'>;
+
+const blog = {
+  collection: 'blog',
+  id: '2026/example-post',
+  data: {
+    title: 'テスト記事',
+    description: 'テスト記事の説明',
+    published: new Date('2026-01-01T00:00:00.000Z'),
+    lastUpdated: new Date('2026-01-02T00:00:00.000Z'),
+    isPublished: true,
+    category: 'programming',
+    emoji: '📝',
+  },
+} as unknown as CollectionEntry<'blog'>;
+
+describe('rich-results', () => {
+  describe('WebsiteLd', () => {
+    it('sets publisher @id to the site organization IRI', () => {
+      const result = WebsiteLd(meta, site);
+      expect(result.publisher).toMatchObject({
+        '@id': 'https://www.funailog.com/#organization',
+      });
+    });
+  });
+
+  describe('ArticleLd', () => {
+    it('sets publisher @id to the site organization IRI', () => {
+      const result = ArticleLd(meta, blog, site);
+      expect(result.publisher).toMatchObject({
+        '@id': 'https://www.funailog.com/#organization',
+      });
+    });
+
+    it('includes mainEntityOfPage pointing at the article URL', () => {
+      const result = ArticleLd(meta, blog, site);
+      expect(result.mainEntityOfPage).toEqual({
+        '@type': 'WebPage',
+        '@id': 'https://www.funailog.com/blog/2026/example-post',
+      });
+    });
+
+    it('keeps existing headline and date fields', () => {
+      const result = ArticleLd(meta, blog, site);
+      expect(result.headline).toBe('テスト記事');
+      expect(result.datePublished).toBe('2026-01-01T00:00:00.000Z');
+      expect(result.dateModified).toBe('2026-01-02T00:00:00.000Z');
+    });
+  });
+});

--- a/src/lib/rich-results.ts
+++ b/src/lib/rich-results.ts
@@ -34,7 +34,7 @@ const publisher = (site: URL | ''): Organization => {
 
   return {
     '@type': 'Organization',
-    '@id': 'paveg/funailog',
+    '@id': `${url}#organization`,
     name: t('main.title'),
     url: url,
   };
@@ -82,6 +82,10 @@ export const ArticleLd = (
     author: [person(meta)],
     publisher: publisher(site),
     isPartOf: WebsiteLd(meta, site),
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': articleUrl,
+    },
   };
 };
 


### PR DESCRIPTION
## 概要

JSON-LD の publisher `@id` が `'paveg/funailog'` という URL でない不正値になっていた。
`@id` は IRI である必要があるため、サイトルートから導出した
`https://www.funailog.com/#organization` に修正する。
あわせて Article に欠けていた `mainEntityOfPage` を追加する。

## 変更内容

- `src/lib/rich-results.ts` の `publisher()`: `@id` を `${url}#organization` に修正
- `ArticleLd`: `mainEntityOfPage: { '@type': 'WebPage', '@id': articleUrl }` を追加
- `src/lib/rich-results.test.ts` を新設（publisher `@id` × 2、mainEntityOfPage、既存フィールドの回帰の計 4 テスト）

publisher.logo の追加は、適切なロゴアセットが無いため意図的にスコープ外とした。

## 検証

- TDD（Red → Green）。修正前にテスト 3 件が期待どおり失敗することを確認
- `pnpm test` 118 件全パス、`pnpm lint` 8 系統 0 エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)
