### PR TITLE
feat(seo): sitemap に lastmod を出力

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import mdx from '@astrojs/mdx';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
@@ -17,8 +19,17 @@ import rehypeTableWrapper from './src/lib/rehype-table-wrapper';
 import rehypeUnwrapSvgP from './src/lib/rehype-unwrap-svg-p';
 import remarkLink from './src/lib/remark-link';
 import { remarkReadingTime } from './src/lib/remark-reading-time';
+import { getBlogPostLastmod } from './src/lib/sitemap-lastmod';
 
 import type { Element } from 'hast';
+
+function readContent(path: string): string | undefined {
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch {
+    return undefined;
+  }
+}
 
 // https://astro.build/config
 export default defineConfig({
@@ -37,7 +48,12 @@ export default defineConfig({
     }),
     expressiveCode(),
     mdx(),
-    sitemap(),
+    sitemap({
+      serialize(item) {
+        const lastmod = getBlogPostLastmod(item.url, readContent);
+        return lastmod ? { ...item, lastmod } : item;
+      },
+    }),
     inline(),
   ],
   build: {

--- a/src/lib/sitemap-lastmod.test.ts
+++ b/src/lib/sitemap-lastmod.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  resolveBlogPostContentPath,
+  extractLastmodDate,
+  getBlogPostLastmod,
+} from './sitemap-lastmod';
+
+describe('resolveBlogPostContentPath', () => {
+  it('resolves a blog post URL with trailing slash to its content path', () => {
+    expect(
+      resolveBlogPostContentPath(
+        'https://www.funailog.com/blog/2026/development-environment-2026/',
+      ),
+    ).toBe('src/content/blog/2026/development-environment-2026.mdx');
+  });
+
+  it('resolves a blog post URL without trailing slash to its content path', () => {
+    expect(
+      resolveBlogPostContentPath(
+        'https://www.funailog.com/blog/2024/blog-replacement',
+      ),
+    ).toBe('src/content/blog/2024/blog-replacement.mdx');
+  });
+
+  it('returns undefined for the top page', () => {
+    expect(
+      resolveBlogPostContentPath('https://www.funailog.com/'),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for tag/category listing pages', () => {
+    expect(
+      resolveBlogPostContentPath('https://www.funailog.com/blog/tags/astro/'),
+    ).toBeUndefined();
+    expect(
+      resolveBlogPostContentPath(
+        'https://www.funailog.com/blog/categories/programming/',
+      ),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for the blog index page', () => {
+    expect(
+      resolveBlogPostContentPath('https://www.funailog.com/blog/'),
+    ).toBeUndefined();
+  });
+});
+
+describe('extractLastmodDate', () => {
+  it('prefers lastUpdated over published when both are present', () => {
+    const content = [
+      '---',
+      'title: 記事タイトル',
+      'published: 2024-03-20',
+      'lastUpdated: 2025-12-24',
+      'isPublished: true',
+      '---',
+      '本文',
+    ].join('\n');
+    expect(extractLastmodDate(content)).toBe('2025-12-24');
+  });
+
+  it('falls back to published when lastUpdated is absent', () => {
+    const content = [
+      '---',
+      'title: 記事タイトル',
+      'published: 2026-01-18',
+      'isPublished: true',
+      '---',
+      '本文',
+    ].join('\n');
+    expect(extractLastmodDate(content)).toBe('2026-01-18');
+  });
+
+  it('returns undefined when neither date is present', () => {
+    const content = ['---', 'title: 記事タイトル', '---', '本文'].join('\n');
+    expect(extractLastmodDate(content)).toBeUndefined();
+  });
+
+  it('returns undefined when the content has no frontmatter block', () => {
+    expect(extractLastmodDate('本文のみ、frontmatterなし')).toBeUndefined();
+  });
+
+  it('ignores a published-looking line in the body, outside frontmatter', () => {
+    const content = [
+      '---',
+      'title: 記事タイトル',
+      '---',
+      'published: 2099-01-01 という表記は本文中の文字列',
+    ].join('\n');
+    expect(extractLastmodDate(content)).toBeUndefined();
+  });
+});
+
+describe('getBlogPostLastmod', () => {
+  it('reads the resolved content path and extracts the lastmod date', () => {
+    const content = [
+      '---',
+      'title: 記事タイトル',
+      'published: 2024-03-20',
+      'lastUpdated: 2025-12-24',
+      '---',
+      '本文',
+    ].join('\n');
+    const readContent = (path: string) =>
+      path === 'src/content/blog/2024/blog-replacement.mdx'
+        ? content
+        : undefined;
+
+    expect(
+      getBlogPostLastmod(
+        'https://www.funailog.com/blog/2024/blog-replacement/',
+        readContent,
+      ),
+    ).toBe('2025-12-24');
+  });
+
+  it('returns undefined for non-blog-post URLs without reading anything', () => {
+    let readCalled = false;
+    const readContent = (): string | undefined => {
+      readCalled = true;
+      return undefined;
+    };
+
+    expect(
+      getBlogPostLastmod('https://www.funailog.com/', readContent),
+    ).toBeUndefined();
+    expect(readCalled).toBe(false);
+  });
+
+  it('returns undefined when the content file cannot be read', () => {
+    const readContent = () => undefined;
+
+    expect(
+      getBlogPostLastmod(
+        'https://www.funailog.com/blog/2099/missing-post/',
+        readContent,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/src/lib/sitemap-lastmod.ts
+++ b/src/lib/sitemap-lastmod.ts
@@ -1,0 +1,57 @@
+const BLOG_POST_PATH_PATTERN = /\/blog\/(\d{4})\/([^/]+)\/?$/;
+const CONTENT_DIR = 'src/content/blog';
+
+/**
+ * `/blog/{year}/{slug}/` 形式のブログ記事 URL を、対応する frontmatter
+ * ファイルへの相対パスに解決する。ブログ記事以外の URL（トップ、タグ、
+ * カテゴリ、ブログ一覧など）は undefined を返す。
+ */
+export function resolveBlogPostContentPath(url: string): string | undefined {
+  const match = BLOG_POST_PATH_PATTERN.exec(new URL(url).pathname);
+  if (!match) return undefined;
+  const [, year, slug] = match;
+  return `${CONTENT_DIR}/${year}/${slug}.mdx`;
+}
+
+const FRONTMATTER_BLOCK_PATTERN = /^---\n([\s\S]*?)\n---/;
+
+function extractFrontmatterDate(
+  frontmatter: string,
+  key: 'published' | 'lastUpdated',
+): string | undefined {
+  const pattern = new RegExp(
+    `^${key}:\\s*['"]?(\\d{4}-\\d{2}-\\d{2})['"]?\\s*$`,
+    'm',
+  );
+  return pattern.exec(frontmatter)?.[1];
+}
+
+/**
+ * MDX の frontmatter から lastmod に使う日付を取り出す。
+ * `lastUpdated` を優先し、無ければ `published` にフォールバックする。
+ * frontmatter が読めない・日付が見つからない場合は undefined を返す。
+ */
+export function extractLastmodDate(content: string): string | undefined {
+  const frontmatter = FRONTMATTER_BLOCK_PATTERN.exec(content)?.[1];
+  if (!frontmatter) return undefined;
+  return (
+    extractFrontmatterDate(frontmatter, 'lastUpdated') ??
+    extractFrontmatterDate(frontmatter, 'published')
+  );
+}
+
+/**
+ * sitemap の各 URL に対する lastmod を求める。
+ * `readContent` は該当パスの読み取りを担う注入ポイントで、ファイルが
+ * 存在しない場合は undefined を返す想定（例外は投げない）。
+ */
+export function getBlogPostLastmod(
+  url: string,
+  readContent: (path: string) => string | undefined,
+): string | undefined {
+  const path = resolveBlogPostContentPath(url);
+  if (!path) return undefined;
+  const content = readContent(path);
+  if (!content) return undefined;
+  return extractLastmodDate(content);
+}


### PR DESCRIPTION
## 概要

`@astrojs/sitemap` をオプション無しで使っていたため、sitemap に `<lastmod>` が出力されていなかった。
`serialize` オプションでブログ記事 URL を frontmatter に解決し、
`lastUpdated ?? published` を lastmod として出力する。

## 変更内容

- `src/lib/sitemap-lastmod.ts` を新設。URL → `src/content/blog/{year}/{slug}.mdx` の解決と、frontmatter からの日付抽出を純関数として実装（新規依存なし、fs は注入）
- `astro.config.ts` の `sitemap()` に `serialize` を追加
- 記事以外の URL（トップ・タグ・カテゴリ・一覧）と、ファイル未検出・日付不明のケースは lastmod 無しのまま返し、ビルドは失敗させない

## 検証

- TDD（Red → Green）。テスト 13 件を新設し `pnpm test` 127 件全パス
- `pnpm lint` 8 系統 0 エラー
- `pnpm build` exit 0。`dist/sitemap-0.xml` で記事 45 本すべてに lastmod が入り、`lastUpdated` 優先（例: fish-to-zsh → 2025-12-24）と `published` フォールバック（例: best-buy-2019 → 2019-12-09）を実記事と突合。タグ・カテゴリ URL に lastmod が無いことも確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
