### PR TITLE
feat(analytics): AffiliateCard に GA4 クリックイベントを追加

### DIFF
--- a/src/components/AffiliateCard.astro
+++ b/src/components/AffiliateCard.astro
@@ -56,6 +56,7 @@ const generateAmazonUrl = (asin: string): string => {
 
 // 各サービスのリンク情報を整形
 interface ServiceLink {
+  shop: string;
   label: string;
   href: string;
   price: string | undefined;
@@ -69,6 +70,7 @@ if (amazon) {
     ? generateAmazonUrl(amazon.asin)
     : amazon.href || '#';
   services.push({
+    shop: 'amazon',
     label: 'Amazon',
     href,
     price: amazon.price,
@@ -78,6 +80,7 @@ if (amazon) {
 
 if (rakuten) {
   services.push({
+    shop: 'rakuten',
     label: '楽天',
     href: rakuten.href || '#',
     price: rakuten.price,
@@ -87,6 +90,7 @@ if (rakuten) {
 
 if (yahoo) {
   services.push({
+    shop: 'yahoo',
     label: 'Yahoo!',
     href: yahoo.href || '#',
     price: yahoo.price,
@@ -96,6 +100,7 @@ if (yahoo) {
 
 if (other) {
   services.push({
+    shop: 'other',
     label: other.label,
     href: other.href || '#',
     price: other.price,
@@ -165,6 +170,8 @@ if (other) {
                   href={service.href}
                   target="_blank"
                   rel="noopener noreferrer sponsored"
+                  data-affiliate-shop={service.shop}
+                  data-affiliate-item={title}
                   class:list={[
                     'inline-flex items-center gap-1.5 rounded-md px-3 py-2',
                     'text-sm font-medium no-underline',
@@ -186,3 +193,22 @@ if (other) {
     </div>
   </Card>
 </div>
+
+<script>
+  document.addEventListener('click', (event) => {
+    if (typeof window.gtag !== 'function') return;
+
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+
+    const link = target.closest<HTMLAnchorElement>('a[data-affiliate-shop]');
+    if (!link) return;
+
+    window.gtag('event', 'affiliate_click', {
+      shop: link.dataset.affiliateShop,
+      item_name: link.dataset.affiliateItem,
+      link_url: link.href,
+      page_path: location.pathname,
+    });
+  });
+</script>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -12,3 +12,7 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+interface Window {
+  gtag?: (...args: unknown[]) => void;
+}


### PR DESCRIPTION
## 概要

AffiliateCard にクリック計測が無く、どのカード・記事が収益に貢献したか追跡できなかった。
ショップリンクのクリックで GA4 カスタムイベント `affiliate_click` を送信する。

## 変更内容

- 各ショップリンクに `data-affiliate-shop`（amazon / rakuten / yahoo / other の安定キー）と `data-affiliate-item`（商品名）を付与
- hoisted module script で document への委譲リスナー 1 本を張り、`gtag('event', 'affiliate_click', { shop, item_name, link_url, page_path })` を送信
- `window.gtag` が無い環境（dev・広告ブロッカー）ではノーオペ。`src/env.d.ts` に `Window.gtag` の型を追加

委譲リスナーは 1 ページに複数カードがあっても二重送信しない。
リンクは `target="_blank"` のためページ遷移によるイベント喪失も起きない。

## 検証

- `pnpm lint`（astro check / tsc / eslint 含む）0 エラー、`pnpm test` 全パス
- dev サーバで /blog/2025/best-buy-2025/ の HTML に data 属性が出力され、トランスパイル後の module script が期待どおりのロジックであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
