### PR TITLE
chore(schema): 未使用の related フィールドを削除

### DIFF
--- a/src/schemas/blog-collection.ts
+++ b/src/schemas/blog-collection.ts
@@ -23,7 +23,6 @@ export const blogCollection = defineCollection({
       ])
       .default('other'),
     tags: z.array(z.string()).optional(),
-    related: z.array(z.string()).optional(),
     series: z.string().optional(),
     seriesTitle: z.string().optional(),
     seriesOrder: z.number().int().positive().optional(),


### PR DESCRIPTION
## 概要

blog スキーマの `related` フィールドは、全 45 記事の frontmatter で未使用かつ
コードからも参照されていない dead field のため削除する。

関連記事機能（`src/lib/related-posts.ts` / `RelatedArticles`）は
category / tags からの自動計算で、このフィールドとは無関係（変更なし）。

## 検証

- `grep` で `data.related` の参照ゼロ、frontmatter での使用ゼロを確認
- `pnpm lint` 8 系統（astro check / tsc / knip 含む）0 エラー、`pnpm test` 114 件全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
