### PR TITLE
fix(seo): canonical と内部リンクの末尾スラッシュを統一

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -25,7 +25,7 @@ const startYear = 2023;
       <p class="font-heading text-foreground font-semibold">Resources</p>
       <ul class="space-y-1">
         <li>
-          <a href="/privacy" class="hover:text-foreground transition-colors"
+          <a href="/privacy/" class="hover:text-foreground transition-colors"
             >Privacy</a
           >
         </li>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,9 +5,13 @@ const url = Astro.url;
 
 const navItems = [
   { href: '/', label: 'Home', match: (p: string) => p === '/' },
-  { href: '/blog', label: 'Blog', match: (p: string) => p.includes('/blog') },
   {
-    href: '/portfolio',
+    href: '/blog/',
+    label: 'Blog',
+    match: (p: string) => p.includes('/blog'),
+  },
+  {
+    href: '/portfolio/',
     label: 'Portfolio',
     match: (p: string) => p.includes('/portfolio'),
   },

--- a/src/components/InfinitePostList.tsx
+++ b/src/components/InfinitePostList.tsx
@@ -108,7 +108,7 @@ function PostItem({ post }: { post: SerializedPost }) {
 
       <div className="text-muted-foreground flex items-center gap-2 text-xs">
         <a
-          href={`/blog/categories/${post.category}`}
+          href={`/blog/categories/${post.category}/`}
           className="category-badge"
         >
           {post.category}
@@ -142,7 +142,7 @@ function PostItem({ post }: { post: SerializedPost }) {
       {tags.length > 0 && (
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1 pt-1.5">
           {tags.slice(0, 5).map((tag) => (
-            <a key={tag} href={`/blog/tags/${tag}`} className="tag-link">
+            <a key={tag} href={`/blog/tags/${tag}/`} className="tag-link">
               #{tag}
             </a>
           ))}

--- a/src/components/article/ArticleHeader.astro
+++ b/src/components/article/ArticleHeader.astro
@@ -31,7 +31,7 @@ const hasDistinctUpdate = !!lastUpdatedOnly && lastUpdatedOnly !== dateOnly;
 <div class="font-code text-muted-foreground my-4 space-y-3 text-xs">
   {/* Date + Category + Reading time */}
   <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
-    <a href={`/${collection}/categories/${category}`} class="category-badge">
+    <a href={`/${collection}/categories/${category}/`} class="category-badge">
       {category}
     </a>
     <span class="flex items-center gap-1">
@@ -103,7 +103,7 @@ const hasDistinctUpdate = !!lastUpdatedOnly && lastUpdatedOnly !== dateOnly;
             <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20" />
           </svg>
           <a
-            href={`/blog/series/${seriesInfo.id}`}
+            href={`/blog/series/${seriesInfo.id}/`}
             class="text-muted-foreground hover:text-link hover:underline"
           >
             {seriesInfo.title}
@@ -119,7 +119,7 @@ const hasDistinctUpdate = !!lastUpdatedOnly && lastUpdatedOnly !== dateOnly;
                   </span>
                 ) : (
                   <a
-                    href={`/blog/${p.id}`}
+                    href={`/blog/${p.id}/`}
                     class="border-border hover:bg-muted hover:border-muted-foreground inline-flex size-6 items-center justify-center rounded-full border text-[11px] transition-colors"
                   >
                     {order}
@@ -138,7 +138,7 @@ const hasDistinctUpdate = !!lastUpdatedOnly && lastUpdatedOnly !== dateOnly;
     tags.length > 0 && (
       <div class="flex flex-wrap gap-1.5">
         {tags.map((tag) => (
-          <a href={`/${collection}/tags/${tag}`} class="tag-link">
+          <a href={`/${collection}/tags/${tag}/`} class="tag-link">
             #{tag}
           </a>
         ))}

--- a/src/components/article/RelatedArticles.astro
+++ b/src/components/article/RelatedArticles.astro
@@ -24,7 +24,7 @@ const t = useTranslations(defaultLang);
         {posts.map((post) => (
           <li>
             <a
-              href={`/blog/${post.id}`}
+              href={`/blog/${post.id}/`}
               class="border-border group hover:border-accent-line hover:bg-surface-sunken block rounded-lg border-l-2 px-4 py-2.5 transition-all duration-150"
             >
               <span class="text-muted-foreground flex items-center gap-2 text-xs">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -14,6 +14,7 @@ import Header from '@/components/Header.astro';
 import { TailwindIndicator } from '@/components/tailwind-indicator';
 import { ui, defaultLang, type SupportedLang } from '@/i18n/ui';
 import { useTranslations } from '@/i18n/utils';
+import { ensureTrailingSlash } from '@/lib/utils';
 
 export type Props = {
   title: string;
@@ -60,7 +61,10 @@ if (!meta) {
     <meta charset="utf-8" />
     <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="canonical" href={new URL(path, site).toString()} />
+    <link
+      rel="canonical"
+      href={new URL(ensureTrailingSlash(path), site).toString()}
+    />
     {noindex && <meta name="robots" content="noindex" />}
     <link
       rel="alternate"
@@ -72,7 +76,7 @@ if (!meta) {
         <link
           rel="alternate"
           hreflang={hl.hreflang}
-          href={new URL(hl.path, site).toString()}
+          href={new URL(ensureTrailingSlash(hl.path), site).toString()}
         />
       ))
     }
@@ -95,7 +99,10 @@ if (!meta) {
     <meta name="publisher" content="Ryota Ikezawa" />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
-    <meta property="og:url" content={new URL(path, site).toString()} />
+    <meta
+      property="og:url"
+      content={new URL(ensureTrailingSlash(path), site).toString()}
+    />
     <meta property="og:site_name" content={meta.data.rss.title} />
     <meta name="twitter:site" content="@paveg_" />
     <meta name="twitter:creator" content="@paveg_" />

--- a/src/lib/rich-results.test.ts
+++ b/src/lib/rich-results.test.ts
@@ -58,7 +58,7 @@ describe('rich-results', () => {
       const result = ArticleLd(meta, blog, site);
       expect(result.mainEntityOfPage).toEqual({
         '@type': 'WebPage',
-        '@id': 'https://www.funailog.com/blog/2026/example-post',
+        '@id': 'https://www.funailog.com/blog/2026/example-post/',
       });
     });
 

--- a/src/lib/rich-results.ts
+++ b/src/lib/rich-results.ts
@@ -13,6 +13,7 @@ import type {
 } from 'schema-dts';
 
 import { useTranslations } from '@/i18n/utils';
+import { ensureTrailingSlash } from '@/lib/utils';
 
 const person = (meta: CollectionEntry<'site'>): Person => {
   return {
@@ -63,7 +64,10 @@ export const ArticleLd = (
   blog: CollectionEntry<'blog'>,
   site: URL | '',
 ): WithContext<Article> => {
-  const articleUrl = new URL(`${blog.collection}/${blog.id}`, site).toString();
+  const articleUrl = new URL(
+    ensureTrailingSlash(`${blog.collection}/${blog.id}`),
+    site,
+  ).toString();
   return {
     '@context': 'https://schema.org',
     '@type': 'Article',

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { ensureTrailingSlash } from './utils';
+
+describe('ensureTrailingSlash', () => {
+  it('appends a trailing slash to a bare path', () => {
+    expect(ensureTrailingSlash('/blog')).toBe('/blog/');
+  });
+
+  it('appends a trailing slash to a nested path', () => {
+    expect(ensureTrailingSlash('/blog/tags/zsh')).toBe('/blog/tags/zsh/');
+  });
+
+  it('leaves a path that already ends with a slash unchanged', () => {
+    expect(ensureTrailingSlash('/blog/')).toBe('/blog/');
+  });
+
+  it('leaves the root path unchanged', () => {
+    expect(ensureTrailingSlash('/')).toBe('/');
+  });
+
+  it('leaves a path with a file extension unchanged', () => {
+    expect(ensureTrailingSlash('/rss.xml')).toBe('/rss.xml');
+  });
+
+  it('leaves a path with a file extension in a nested directory unchanged', () => {
+    expect(ensureTrailingSlash('/api/og/article/2026/foo.png')).toBe(
+      '/api/og/article/2026/foo.png',
+    );
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -23,3 +23,18 @@ export function formatDateEn(date: Date): string {
     day: 'numeric',
   }).format(date);
 }
+
+const FILE_EXTENSION_PATTERN = /\.[a-zA-Z0-9]+$/;
+
+/**
+ * Ensure an internal page path ends with a trailing slash, matching the
+ * directory-style URLs Astro emits (`build.format: 'directory'`).
+ * Paths ending in a file extension (rss.xml, og images, ...) are returned
+ * unchanged, since those are served as files, not directories.
+ */
+export function ensureTrailingSlash(path: string): string {
+  if (path.endsWith('/') || FILE_EXTENSION_PATTERN.test(path)) {
+    return path;
+  }
+  return `${path}/`;
+}

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -46,7 +46,7 @@ const meta = await getEntry('site', 'meta');
 if (!meta) {
   throw new Error('Site meta configuration not found');
 }
-const pageUrl = new URL(`/${page.id}`, site).toString();
+const pageUrl = new URL(`/${page.id}/`, site).toString();
 const homeUrl = new URL('/', site).toString();
 ---
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -24,6 +24,7 @@ import Layout from '@/layouts/Layout.astro';
 import { isVisible } from '@/lib/posts';
 import { getRelatedPosts } from '@/lib/related-posts';
 import { ArticleLd, BreadcrumbLd } from '@/lib/rich-results';
+import { ensureTrailingSlash } from '@/lib/utils';
 
 const meta = await getEntry('site', 'meta');
 if (!meta) {
@@ -51,7 +52,7 @@ const components = {
 };
 const site = Astro.site ?? '';
 const path = `${post.collection}/${post.id}`;
-const fullUrl = new URL(path, site).toString();
+const fullUrl = new URL(ensureTrailingSlash(path), site).toString();
 const t = useTranslations(defaultLang);
 const relatedPosts = getRelatedPosts(post, publishedPosts);
 const seriesPosts = post.data.series
@@ -101,7 +102,7 @@ const nextInSeries = seriesPosts.find(
     ArticleLd(meta, post, site),
     BreadcrumbLd([
       { name: t('main.title'), url: new URL('/', site).toString() },
-      { name: t('blog.index'), url: new URL('/blog', site).toString() },
+      { name: t('blog.index'), url: new URL('/blog/', site).toString() },
       { name: post.data.title, url: fullUrl },
     ]),
   ]}
@@ -140,7 +141,7 @@ const nextInSeries = seriesPosts.find(
         nextInSeries && (
           <div class="mt-12">
             <a
-              href={`/blog/${nextInSeries.id}`}
+              href={`/blog/${nextInSeries.id}/`}
               class="text-muted-foreground hover:text-link group inline-flex items-center gap-1.5 text-sm transition-colors"
             >
               <span>Next:</span>

--- a/src/pages/blog/archive.astro
+++ b/src/pages/blog/archive.astro
@@ -20,9 +20,9 @@ const meta = await getEntry('site', 'meta');
 if (!meta) {
   throw new Error('Site meta configuration not found');
 }
-const pageUrl = new URL('/blog/archive', site).toString();
+const pageUrl = new URL('/blog/archive/', site).toString();
 const homeUrl = new URL('/', site).toString();
-const blogUrl = new URL('/blog', site).toString();
+const blogUrl = new URL('/blog/', site).toString();
 
 const posts = sortUnifiedPosts(
   (await getCollection('blog')).filter(isVisible).map(blogToUnified),

--- a/src/pages/blog/categories/[category].astro
+++ b/src/pages/blog/categories/[category].astro
@@ -40,9 +40,9 @@ if (!meta) {
   throw new Error('Site meta configuration not found');
 }
 const basePath = `blog/categories/${category}`;
-const pageUrl = new URL(`/${basePath}`, site).toString();
+const pageUrl = new URL(`/${basePath}/`, site).toString();
 const homeUrl = new URL('/', site).toString();
-const blogUrl = new URL('/blog', site).toString();
+const blogUrl = new URL('/blog/', site).toString();
 
 const sortedPosts = sortUnifiedPosts(posts.map(blogToUnified));
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -16,7 +16,7 @@ const meta = await getEntry('site', 'meta');
 if (!meta) {
   throw new Error('Site meta configuration not found');
 }
-const pageUrl = new URL('/blog', site).toString();
+const pageUrl = new URL('/blog/', site).toString();
 const homeUrl = new URL('/', site).toString();
 
 // Fetch blog posts
@@ -74,7 +74,7 @@ const serializedPosts = allPosts.map((post) => ({
       featuredCount={4}
     />
     <p class="text-muted-foreground pb-8 text-center text-xs">
-      <a href="/blog/archive" class="hover:text-foreground transition-colors">
+      <a href="/blog/archive/" class="hover:text-foreground transition-colors">
         {t('archive.linkText')}
       </a>
     </p>

--- a/src/pages/blog/series/[series].astro
+++ b/src/pages/blog/series/[series].astro
@@ -51,9 +51,9 @@ if (!meta) {
   throw new Error('Site meta configuration not found');
 }
 const basePath = `blog/series/${series}`;
-const pageUrl = new URL(`/${basePath}`, site).toString();
+const pageUrl = new URL(`/${basePath}/`, site).toString();
 const homeUrl = new URL('/', site).toString();
-const blogUrl = new URL('/blog', site).toString();
+const blogUrl = new URL('/blog/', site).toString();
 
 const unifiedPosts = posts.map(blogToUnified);
 ---

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -40,9 +40,9 @@ if (!meta) {
   throw new Error('Site meta configuration not found');
 }
 const basePath = `blog/tags/${tag}`;
-const pageUrl = new URL(`/${basePath}`, site).toString();
+const pageUrl = new URL(`/${basePath}/`, site).toString();
 const homeUrl = new URL('/', site).toString();
-const blogUrl = new URL('/blog', site).toString();
+const blogUrl = new URL('/blog/', site).toString();
 
 const sortedPosts = sortUnifiedPosts(posts.map(blogToUnified));
 

--- a/src/pages/en/portfolio.astro
+++ b/src/pages/en/portfolio.astro
@@ -19,7 +19,7 @@ if (!meta) {
   throw new Error('Site meta configuration not found');
 }
 const portfolio = await getEntry('portfolio', 'profile-en');
-const pageUrl = new URL('/en/portfolio', site).toString();
+const pageUrl = new URL('/en/portfolio/', site).toString();
 const homeUrl = new URL('/', site).toString();
 
 if (!portfolio) {
@@ -56,7 +56,7 @@ if (!portfolio) {
   <div class="space-y-12">
     <div class="flex justify-end">
       <a
-        href="/portfolio"
+        href="/portfolio/"
         class="font-code text-muted-foreground hover:text-foreground text-xs transition-colors"
       >
         日本語 &rarr;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -91,7 +91,7 @@ const otherPosts = recentPosts.slice(1);
 
       <div class="mt-8 text-center">
         <a
-          href="/blog"
+          href="/blog/"
           class="border-border hover:bg-accent hover:text-accent-foreground text-muted-foreground inline-flex items-center gap-1.5 rounded-md border px-4 py-2 text-sm transition-colors"
         >
           {t('index.viewAllPosts')} &rarr;

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -20,7 +20,7 @@ if (!meta) {
   throw new Error('Site meta configuration not found');
 }
 const portfolio = await getEntry('portfolio', 'profile');
-const pageUrl = new URL('/portfolio', site).toString();
+const pageUrl = new URL('/portfolio/', site).toString();
 const homeUrl = new URL('/', site).toString();
 
 if (!portfolio) {
@@ -56,7 +56,7 @@ if (!portfolio) {
   <div class="space-y-12">
     <div class="flex justify-end">
       <a
-        href="/en/portfolio"
+        href="/en/portfolio/"
         class="font-code text-muted-foreground hover:text-foreground text-xs transition-colors"
       >
         English &rarr;

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -17,7 +17,7 @@ export async function GET(context: APIContext) {
     description: meta.data.rss.description,
     site: context.site ?? '',
     items: posts.map((post) => {
-      const url = `/${post.collection}/${post.id}`;
+      const url = `/${post.collection}/${post.id}/`;
       return {
         title: post.data.title,
         description: post.data.description,

--- a/src/types/unified-post.ts
+++ b/src/types/unified-post.ts
@@ -30,7 +30,7 @@ export function blogToUnified(post: CollectionEntry<'blog'>): UnifiedPost {
     lastUpdated: post.data.lastUpdated,
     category: post.data.category,
     tags: post.data.tags,
-    url: `/blog/${post.id}`,
+    url: `/blog/${post.id}/`,
     collection: post.collection,
     originalPost: post,
   };


### PR DESCRIPTION
## 概要

配信 URL はディレクトリ形式（`/blog/tags/zsh/`）なのに、canonical・og:url・JSON-LD・内部リンクが
末尾スラッシュ無しで生成されていた。
Search Console で、スラッシュ有無の両変種が別 URL としてクロールされ、
タグ・カテゴリページや一部記事が「クロール済み・インデックス未登録」（44 件）に落ちているのを確認した。

## 変更内容

- `ensureTrailingSlash` ヘルパーを `src/lib/utils.ts` に追加（拡張子付きパスは対象外）。TDD でテスト新設
- `Layout.astro` の canonical / og:url / hreflang を一括正規化
- JSON-LD の URL（ArticleLd の `@id`・`mainEntityOfPage`、各ページの Breadcrumb / CollectionPage）を統一
- 内部リンク生成を統一: `unified-post.ts`（記事 URL の大元）、`InfinitePostList`、Header / Footer、
  ArticleHeader / RelatedArticles、シリーズ next リンク、各一覧ページ、RSS の記事 link、`/api/posts.json`
- 対象外（意図的）: `rss.xml`・`llms.txt`・OG 画像などファイル系 URL

## 検証

- TDD Red → Green。`pnpm test` 137 件全パス、`pnpm lint` 8 系統 exit 0
- `pnpm build` exit 0（247 ページ）。dist に対して機械的に確認:
  - 全サンプルページの canonical が末尾スラッシュ付き
  - 拡張子なし・スラッシュなしの内部リンクがゼロ件（マッチ件数が非ゼロであることも確認済み = 空振りでない）
  - 記事ページの canonical・`@id`・`mainEntityOfPage.@id`・og:url が完全一致

## 既知の残課題（スコープ外）

- `404.astro` / `demos/eml.astro` の canonical が `/404/` になるが、両者とも noindex のため実害なし
- タグ名にドットが含まれる場合（例: `web3.0`）は拡張子と誤判定される。現状該当タグなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
