### PR TITLE
feat(seo): 旧 URL 構造の 301 リダイレクトを追加

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,11 @@
+/about /portfolio/ 301
+/about/ /portfolio/ 301
+/en /en/portfolio/ 301
+/en/ /en/portfolio/ 301
+/articles/preducts-first-impression /blog/2023/preducts-first-impression/ 301
+/articles/preducts-first-impression/ /blog/2023/preducts-first-impression/ 301
+/articles/popular-articles-with-google-analytics-4 /blog/2023/popular-articles-with-google-analytics-4/ 301
+/articles/popular-articles-with-google-analytics-4/ /blog/2023/popular-articles-with-google-analytics-4/ 301
+/2026/harness-engineering-landscape /blog/2026/harness-engineering-landscape/ 301
+/2026/harness-engineering-landscape/ /blog/2026/harness-engineering-landscape/ 301
+/blog/en/* /blog/:splat 301


### PR DESCRIPTION
## 概要

Search Console で 404 が 17 件検出された。旧 URL 構造の残骸のうち、
行き先が現存するものを `public/_redirects`（Cloudflare Workers static assets）で 301 リダイレクトする。

## 変更内容

`public/_redirects` を新規追加（11 ルール）。

- `/about` → `/portfolio/`（about ページはコンテンツ自体が存在しない。`src/content/page/` は privacy のみ）
- `/en` → `/en/portfolio/`
- `/articles/{preducts-first-impression, popular-articles-with-google-analytics-4}` → `/blog/2023/…/`
- `/2026/harness-engineering-landscape` → `/blog/2026/…/`
- `/blog/en/*` → `/blog/:splat`（旧英語ツリー）

Cloudflare の `_redirects` はソース側の末尾スラッシュを自動正規化しないことを
`wrangler dev` で実測確認したため、完全一致ルールはスラッシュ有無の両変種を記載している。
`/zenn/`・`/posts/*`・`/opengraph/*`・`/styleguide/` は行き先が無いため意図的に対象外（404 のまま）。

## 検証

- リダイレクト先の実在をファイルレベルで確認
- `pnpm build` で `dist/_redirects` の生成を確認
- `npx wrangler dev` で 16 パスを実測: 5 ターゲット × 両変種すべて 301、`curl -L` で
  `final_status=200 num_redirects=1`（単一ホップ、チェーンなし）、除外 4 パスは 404 のまま
- `pnpm test` 回帰なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
