### PR TITLE
perf(images): リモート画像をビルド時最適化の対象にする

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -59,6 +59,12 @@ export default defineConfig({
   build: {
     format: 'directory',
   },
+  image: {
+    // ブログ記事で参照するリモート画像（microCMS 添付・imgix 経由の手動アップロード）を
+    // ビルド時最適化の対象にする。未登録のリモートドメインは astro:assets の <Image> で
+    // 最適化がスキップされる。
+    domains: ['images.microcms-assets.io', 'funailog.imgix.net'],
+  },
   prefetch: {
     defaultStrategy: 'hover',
     prefetchAll: true,


### PR DESCRIPTION
## 概要

Lighthouse（モバイル）で記事ページがスコア 39、LCP 15.5 秒だった。
主因はヒーロー画像で、astro:assets の `<Image>` を使っているのに
リモートドメインが `image.domains` 未登録のため最適化がスキップされ、
926KB の PNG が素通しで配信されていた（srcset も同一 URL を並べるだけの無効な状態）。

## 変更内容

`astro.config.ts` に `image.domains: ['images.microcms-assets.io', 'funailog.imgix.net']` を追加。
コード変更はこの 1 箇所のみで、hero と本文画像は既に同じ `<Image>` 経路を通っているため、
ドメイン許可だけでビルド時最適化（sharp）が有効になる。

## 検証

- `pnpm build` exit 0（251 ページ）。kanademono 記事の hero が `/_astro/*.webp` になり、
  **926KB → 62KB（-93%）**。srcset は 576w〜1600w の実アセットを指す
  （ソースが約 1200px のため 1200w 以上は同一ファイルにクランプ。アップスケールはしない挙動）
- 本文画像も microCMS（mx-ergo 記事）・imgix（uncovered-lc250 記事）の両ドメインで WebP 化を確認
- OG 生成（dist/api/og/ 47 ファイル）への影響なし
- ビルド時間: コールドキャッシュ +12 秒（リモート画像の取得・変換）、
  `node_modules/.astro` にキャッシュされ 2 回目以降は従来どおり約 15 秒
- `pnpm test` 137 件全パス、lint は 8 系統中 7 系統クリーン
  （prettier の失敗は untracked なローカルファイル起因で本変更と無関係、main でも同様に発生することを確認済み）

m.media-amazon.com のアフィリエイト商品画像は意図的に対象外（外部 CDN のまま）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
