### PR TITLE
perf(css): フォント @font-face 群を HTML インラインから除外

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -54,7 +54,11 @@ export default defineConfig({
         return lastmod ? { ...item, lastmod } : item;
       },
     }),
-    inline(),
+    inline({
+      // LINE Seed JP の unicode-range サブセット @font-face 群は 16 進羅列で gzip が効かず、
+      // 全ページの HTML にインライン化すると転送量が膨らむ。外部 CSS のまま配信してキャッシュを効かせる。
+      Beasties: { inlineFonts: false },
+    }),
   ],
   build: {
     format: 'directory',


### PR DESCRIPTION
## 概要

PSI（モバイル）で記事ページの FCP が 7.4 秒。
原因を実測したところ、`Layout.*.css`（gzip 147KB）の 91% が
LINE Seed JP の unicode-range サブセット @font-face 254 個で
（16 進の羅列は gzip が効かない）、`@playform/inline` がこれを
全ページの HTML にインライン化して HTML が gzip 158KB になっていた。

根本原因は `@playform/inline` が beasties の既定値
（`inlineFonts: false`）をラッパー側で `true` に上書きしていること。

## 変更内容

`inline()` に `Beasties: { inlineFonts: false }` を明示。
フォント定義は外部 CSS（全ページ共有・キャッシュ可能）のまま配信し、
woff2 のサブセット単位オンデマンド取得はそのまま維持する。

## 検証

- ビルドログ: beasties のインライン量 305KB（87%）→ 19.6KB（5%）
- 記事 HTML（kanademono）: 生 394KB → 102KB、**gzip 158KB → 23KB（-85%）**
- HTML 内の @font-face: 254 → 0。外部 `Layout.*.css`（gz 146KB）に全 254 定義が残り、
  `<link rel="stylesheet">`（async + noscript フォールバック）で参照
- dist を http.server でサーブし、HTML / CSS / woff2 がすべて 200 で取得できること、
  woff2 のマジックバイトを確認
- `pnpm test` 137 件全パス、lint 8 系統中 7 系統クリーン
  （prettier の失敗は untracked ローカルファイル起因で main でも同一。本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
