### PR TITLE
perf(css): CSS 配信を分離し遅延適用による CLS を解消

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -5,7 +5,6 @@ import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import { defineConfig } from 'astro/config';
 
-import inline from '@playform/inline';
 import tailwindcss from '@tailwindcss/vite';
 import embeds from 'astro-embed/integration';
 import expressiveCode from 'astro-expressive-code';
@@ -54,14 +53,10 @@ export default defineConfig({
         return lastmod ? { ...item, lastmod } : item;
       },
     }),
-    inline({
-      // LINE Seed JP の unicode-range サブセット @font-face 群は 16 進羅列で gzip が効かず、
-      // 全ページの HTML にインライン化すると転送量が膨らむ。外部 CSS のまま配信してキャッシュを効かせる。
-      Beasties: { inlineFonts: false },
-    }),
   ],
   build: {
     format: 'directory',
+    inlineStylesheets: 'always',
   },
   image: {
     // ブログ記事で参照するリモート画像（microCMS 添付・imgix 経由の手動アップロード）を

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "@axe-core/playwright": "4.11.3",
     "@eslint/eslintrc": "^3.3.3",
     "@eslint/js": "^9.39.2",
-    "@playform/inline": "0.1.2",
     "@playwright/test": "1.60.0",
     "@tailwindcss/typography": "^0.5.19",
     "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,9 +126,6 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
-      '@playform/inline':
-        specifier: 0.1.2
-        version: 0.1.2(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.30.2)(rollup@4.60.2)(tsx@4.21.0)(yaml@2.8.3)
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
@@ -1519,12 +1516,6 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playform/inline@0.1.2':
-    resolution: {integrity: sha512-Eqk1FbKc1bNf5zyTBzrqeUvH0qExIzf6auw+yDXRl2MMZOt72FXQfnES1dtdxgjIEf4TDbPBtJ1rTofp52vDvQ==}
-
-  '@playform/pipe@0.1.3':
-    resolution: {integrity: sha512-cjRcaj6b8XZMS+N51In78EuD9e0x0M3gYxi2g+qUGk1iya2uxcS+aSrXxfBUZueOjxADQwpyS4zLEhlbHCGcDA==}
-
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
@@ -2107,9 +2098,6 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
-  '@types/node@22.13.14':
-    resolution: {integrity: sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==}
-
   '@types/node@24.10.4':
     resolution: {integrity: sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==}
 
@@ -2512,10 +2500,6 @@ packages:
 
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
-
-  beasties@0.2.0:
-    resolution: {integrity: sha512-Ljqskqx/tbZagIglYoJIMzH5zgssyp+in9+9sAyh15N22AornBeIDnb8EZ6Rk+6ShfMxd92uO3gfpT0NtZbpow==}
-    engines: {node: '>=14.0.0'}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -3045,10 +3029,6 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
-    engines: {node: '>=16.0.0'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -3925,9 +3905,6 @@ packages:
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
-
-  htmlparser2@9.1.0:
-    resolution: {integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -5326,9 +5303,6 @@ packages:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
 
-  postcss-media-query-parser@0.2.3:
-    resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==}
-
   postcss-nested@6.2.0:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
@@ -6241,9 +6215,6 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
-
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -7973,52 +7944,6 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playform/inline@0.1.2(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.30.2)(rollup@4.60.2)(tsx@4.21.0)(yaml@2.8.3)':
-    dependencies:
-      '@playform/pipe': 0.1.3
-      astro: 6.3.6(@types/node@24.10.4)(jiti@2.7.0)(lightningcss@1.30.2)(rollup@4.60.2)(tsx@4.21.0)(yaml@2.8.3)
-      beasties: 0.2.0
-      deepmerge-ts: 7.1.5
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@types/node'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - db0
-      - idb-keyval
-      - ioredis
-      - jiti
-      - less
-      - lightningcss
-      - rollup
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - uploadthing
-      - yaml
-
-  '@playform/pipe@0.1.3':
-    dependencies:
-      '@types/node': 22.13.14
-      deepmerge-ts: 7.1.5
-      fast-glob: 3.3.3
-
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
@@ -8698,10 +8623,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/node@22.13.14':
-    dependencies:
-      undici-types: 6.20.0
-
   '@types/node@24.10.4':
     dependencies:
       undici-types: 7.16.0
@@ -9295,17 +9216,6 @@ snapshots:
 
   bcp-47-match@2.0.3: {}
 
-  beasties@0.2.0:
-    dependencies:
-      css-select: 5.2.2
-      css-what: 6.2.2
-      dom-serializer: 2.0.0
-      domhandler: 5.0.3
-      htmlparser2: 9.1.0
-      picocolors: 1.1.1
-      postcss: 8.5.10
-      postcss-media-query-parser: 0.2.3
-
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -9845,8 +9755,6 @@ snapshots:
       character-entities: 2.0.2
 
   deep-is@0.1.4: {}
-
-  deepmerge-ts@7.1.5: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -11161,13 +11069,6 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 7.0.1
-
-  htmlparser2@9.1.0:
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      entities: 4.5.0
 
   http-cache-semantics@4.2.0: {}
 
@@ -12924,8 +12825,6 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-media-query-parser@0.2.3: {}
-
   postcss-nested@6.2.0(postcss@8.5.10):
     dependencies:
       postcss: 8.5.10
@@ -14110,8 +14009,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   uncrypto@0.1.3: {}
-
-  undici-types@6.20.0: {}
 
   undici-types@7.16.0: {}
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -15,6 +15,7 @@ import { TailwindIndicator } from '@/components/tailwind-indicator';
 import { ui, defaultLang, type SupportedLang } from '@/i18n/ui';
 import { useTranslations } from '@/i18n/utils';
 import { ensureTrailingSlash } from '@/lib/utils';
+import fontsCssUrl from '@/styles/fonts.css?url';
 
 export type Props = {
   title: string;
@@ -61,6 +62,15 @@ if (!meta) {
     <meta charset="utf-8" />
     <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      rel="stylesheet"
+      href={fontsCssUrl}
+      media="print"
+      onload="this.media='all'"
+    />
+    <noscript>
+      <link rel="stylesheet" href={fontsCssUrl} />
+    </noscript>
     <link
       rel="canonical"
       href={new URL(ensureTrailingSlash(path), site).toString()}

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,0 +1,3 @@
+@import '@fontsource/line-seed-jp/400.css';
+@import '@fontsource/line-seed-jp/700.css';
+@import '@fontsource-variable/jetbrains-mono/index.css';

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,7 +1,4 @@
 @import 'tailwindcss';
-@import '@fontsource/line-seed-jp/400.css';
-@import '@fontsource/line-seed-jp/700.css';
-@import '@fontsource-variable/jetbrains-mono/index.css';
 @plugin '@tailwindcss/typography';
 
 /* ─── Dark mode: class strategy ────────────────────────── */


### PR DESCRIPTION
## 概要

残存していたモバイル CLS 約 0.25 の原因は、`@playform/inline`（beasties）が
Layout.css 全体を media=print トリックで遅延適用し、
非クリティカル CSS が後から当たってレイアウトが動くという配信方式そのものだった
（遅延 CSS チャンクをブロックすると CLS が 3/3 回で 0 になることを対照実験で確認。
フォント preload・img サイジング・メトリクス互換フォールバックは
いずれも実測で無効と確認済み）。

## 変更内容

- `@fontsource` の @import 3 本を `src/styles/fonts.css` に分離し、
  `?url` アセット参照 + `media="print"` / onload / noscript で非同期読み込み
- `@playform/inline` を廃止（integration・依存とも削除）
- 本体 CSS（フォント抜き gz 約 11KB）は `build.inlineStylesheets: 'always'` で
  各ページの `<style>` に静的インライン化 — 外部 CSS への RTT なし・遅延適用なしを両立

## 検証（devtools throttling、mobile、ABAB 交互 4 回の中央値）

| 指標 | before | after |
| :-- | --: | --: |
| CLS | 0.2546 | **0.0003** |
| FCP | 887 ms | 1376 ms（+489ms、許容内） |
| LCP | 2284 ms | 2587 ms |
| Lighthouse score | 0.825 | **0.97** |

- 別記事（moving-with-claude-code-and-todoist）でも CLS 0.0006〜0.0008 を確認
- 記事 HTML は gz 約 34KB（本体 CSS 内包）。フォント CSS（gz 130KB）は
  全ページ共有の外部キャッシュのまま、woff2 の 200 応答も確認
- `pnpm lint` 8 系統・`pnpm test` 137 件・`pnpm test:a11y` 5 ページすべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
