### PR TITLE
perf(cache): ハッシュ付き /_astro アセットに immutable 長期キャッシュを設定

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,3 +1,6 @@
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
 /llms.txt
   Content-Type: text/plain; charset=utf-8
 


### PR DESCRIPTION
## 概要

Cloudflare Observatory の実測で「long cache lifetime」の指摘。
確認したところ、全アセットが `public, max-age=0, must-revalidate` で配信されており、
再訪問のたびに全ファイルの ETag 再検証（304 のラウンドトリップ）が発生していた。

## 変更内容

`public/_headers` に 3 行追加し、`/_astro/*` に
`Cache-Control: public, max-age=31536000, immutable` を設定。

- `/_astro/*` はコンテンツハッシュ付きファイル名（内容が変われば URL も変わる）なので
  1 年 + immutable が安全。フォント CSS（gz 130KB）・woff2・最適化画像の
  再訪問コストがゼロになる
- HTML は従来どおり `max-age=0`（更新の即時反映を維持）

## 検証

- 既存の `_headers`（llms.txt の Content-Type）が本番で機能していることは確認済みで、
  同一の仕組みに乗せるだけの変更
- デプロイ後に `/_astro/*` のレスポンスヘッダで `immutable` を確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)
